### PR TITLE
Dockerfile of a Docker Container for Calvin

### DIFF
--- a/calvin/examples/Dockerfile
+++ b/calvin/examples/Dockerfile
@@ -6,4 +6,3 @@ RUN git clone -b develop https://github.com/EricssonResearch/calvin-base calvin-
 RUN cd calvin-base && pip install -e .
 RUN apk del git gcc python-dev musl-dev && rm -rf /var/cache/apk/*
 ENTRYPOINT ["/bin/sh"]
-

--- a/calvin/examples/Dockerfile
+++ b/calvin/examples/Dockerfile
@@ -1,18 +1,9 @@
 FROM alpine:3.2
-RUN apk --update add python
-RUN apk add git
+RUN apk update && apk add gcc git python python-dev musl-dev
 RUN wget https://bootstrap.pypa.io/ez_setup.py -O - | python
 RUN easy_install pip
-RUN apk add gcc
-RUN apk add python-dev
-RUN apk add musl-dev
-RUN git clone -b Release-0.1.0 https://github.com/EricssonResearch/calvin-base calvin01
-RUN cd calvin01 && python setup.py install
-RUN git clone https://github.com/EricssonResearch/calvin-base calvin
-RUN cd calvin && python setup.py install
-RUN csruntime --host localhost calvin01/calvin/tests/scripts/test1.calvin
-RUN apk del gcc
-RUN apk del python-dev
-RUN apk del musl-dev
-RUN rm -rf /var/cache/apk/*
-ENTRYPOINT ["python"]
+RUN git clone -b develop https://github.com/EricssonResearch/calvin-base calvin-base
+RUN cd calvin-base && pip install -e .
+RUN apk del git gcc python-dev musl-dev && rm -rf /var/cache/apk/*
+ENTRYPOINT ["/bin/sh"]
+

--- a/calvin/examples/Dockerfile
+++ b/calvin/examples/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.2
+RUN apk --update add python
+RUN apk add git
+RUN wget https://bootstrap.pypa.io/ez_setup.py -O - | python
+RUN easy_install pip
+RUN apk add gcc
+RUN apk add python-dev
+RUN apk add musl-dev
+RUN git clone -b Release-0.1.0 https://github.com/EricssonResearch/calvin-base calvin01
+RUN cd calvin01 && python setup.py install
+RUN git clone https://github.com/EricssonResearch/calvin-base calvin
+RUN cd calvin && python setup.py install
+RUN csruntime --host localhost calvin01/calvin/tests/scripts/test1.calvin
+RUN apk del gcc
+RUN apk del python-dev
+RUN apk del musl-dev
+RUN rm -rf /var/cache/apk/*
+ENTRYPOINT ["python"]

--- a/calvin/examples/Dockerfile.1Run
+++ b/calvin/examples/Dockerfile.1Run
@@ -1,11 +1,8 @@
 FROM alpine:3.2
 RUN apk --update add python py-pip openssl ca-certificates && pip install -U setuptools
-RUN apk --update add --virtual build-dependencies git gcc python-dev musl-dev build-base wget \
-        && git clone -b Release-0.1.0 https://github.com/EricssonResearch/calvin-base calvin01 \
-        && cd calvin01 && python setup.py install && cd .. \
-        && git clone https://github.com/EricssonResearch/calvin-base calvin \
-        && cd calvin && python setup.py install && cd .. \
-        && csruntime --host localhost calvin01/calvin/tests/scripts/test1.calvin \
+RUN apk --update add --virtual build-dependencies build-base git gcc python-dev musl-dev wget \
+        && git clone -b develop https://github.com/EricssonResearch/calvin-base calvin-base \
+        && cd calvin-base && pip install -e . && cd .. \
         && apk del build-dependencies \
         && rm -rf /var/cache/apk/*
-ENTRYPOINT ["python"]
+ENTRYPOINT ["csruntime", "--host", "$(awk 'NR==1 { print $1 }' /etc/hosts)"]

--- a/calvin/examples/Dockerfile.1Run
+++ b/calvin/examples/Dockerfile.1Run
@@ -1,0 +1,11 @@
+FROM alpine:3.2
+RUN apk --update add python py-pip openssl ca-certificates && pip install -U setuptools
+RUN apk --update add --virtual build-dependencies git gcc python-dev musl-dev build-base wget \
+        && git clone -b Release-0.1.0 https://github.com/EricssonResearch/calvin-base calvin01 \
+        && cd calvin01 && python setup.py install && cd .. \
+        && git clone https://github.com/EricssonResearch/calvin-base calvin \
+        && cd calvin && python setup.py install && cd .. \
+        && csruntime --host localhost calvin01/calvin/tests/scripts/test1.calvin \
+        && apk del build-dependencies \
+        && rm -rf /var/cache/apk/*
+ENTRYPOINT ["python"]

--- a/calvin/examples/Dockerfiles.readme
+++ b/calvin/examples/Dockerfiles.readme
@@ -1,0 +1,13 @@
+The containers are based on Alpine Linux base image. The develop branch of calvin is installed. The current container image size would be around 115 MB (it could be furthermore reduced).
+
+1. To build the image:
+sudo docker build -t imriss/calvin:1.0 .
+
+2. To fix a bug:
+ID=$(sudo docker run -d imriss/calvin:1.0 /bin/sh)
+sudo docker export $ID | sudo docker import - imriss/calvin:1.5
+
+3. To run in interactive mode:
+sudo docker run -t -i imriss/calvin:1.5 /bin/sh
+
+Note: Step 2 is required for now because starting version 1.0 in interactive mode results in an ELF error to be fixed.

--- a/calvin/examples/Install_on_ArchLinux.readme
+++ b/calvin/examples/Install_on_ArchLinux.readme
@@ -1,0 +1,19 @@
+# Some of the steps that can be used to install the develop branch on Arch Linux:
+
+# step 1:
+sudo pacman -Syyu git
+
+# step 2:
+sudo wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python2
+
+# step 3:
+sudo easy_install pip
+
+# step 4:
+git clone -b develop https://github.com/EricssonResearch/calvin-base calvin-base
+
+# step 5:
+cd calvin-base && sudo pip2 install -e .
+
+# step 6, test (we are in calvin-base/):
+csruntime --host localhost calvin/examples/sample-scripts/test1.calvin


### PR DESCRIPTION
It is based on Alpine Linux base image. Develop branch is installed. The current container image size would be around 115 MB (it could be furthermore reduced).

1. To build the image: 
sudo docker build -t imriss/calvin:1.0 .

2. To fix a bug:
ID=$(sudo docker run -d imriss/calvin:1.0 /bin/sh)
sudo docker export $ID | sudo docker import - imriss/calvin:1.5

3. To run in interactive mode:
sudo docker run -t -i imriss/calvin:1.5 /bin/sh

Note: Step 2 is required for now because starting version 1.0 in interactive mode results in an ELF error to be fixed.