### PR TITLE
fix bug when running actor manager tests

### DIFF
--- a/calvin/tests/test_actormanager.py
+++ b/calvin/tests/test_actormanager.py
@@ -17,6 +17,7 @@
 import unittest
 import mock
 from calvin.runtime.north.actormanager import ActorManager
+from calvin.runtime.north import metering
 
 
 class DummyNode:
@@ -25,10 +26,11 @@ class DummyNode:
         self.id = id(self)
         self.pm = mock.Mock()
         self.storage = mock.Mock()
+        self.control = mock.Mock()
+        self.metering = metering.set_metering(metering.Metering(self))
 
     def calvinsys(self):
         return None
-
 
 
 class ActorManagerTests(unittest.TestCase):


### PR DESCRIPTION
Fixed a bug when metering was None when running test_actormanager