### PR TITLE
Fix delete actor bug

### DIFF
--- a/calvin/Tools/www/js/calvin.js
+++ b/calvin/Tools/www/js/calvin.js
@@ -514,7 +514,17 @@ function getApplications()
 // Get application with id "id"
 function getApplication(uri, id)
 {
-    var url = uri + '/application/' + id;
+    var application = findApplication(id);
+    if (!application) {
+        application = new applicationObject(id);
+        applications[applications.length] = application;
+    }
+    loadApplicationActors(uri, application);
+    loadApplicationData(uri, application);
+}
+
+function loadApplicationData(uri, application) {
+    var url = uri + '/application/' + application.id;
     console.log("getApplication - url: " + url);
     $.ajax({
         uri: uri,
@@ -531,14 +541,9 @@ function getApplication(uri, id)
         success: function(data) {
             if (data) {
                 console.log("getApplication - Response: " + JSON.stringify(data));
-                var application = findApplication(id);
-                if (!application) {
-                    application = new applicationObject(id);
-                    applications[applications.length] = application;
-                }
                 application.name = data.name;
-                application.actors = data.actors;
                 application.control_uri = this.uri;
+
                 var applicationSelector = document.getElementById("applicationSelector");
                 var optionApplication = new Option(application.name);
                 optionApplication.id =  application.id;
@@ -556,6 +561,35 @@ function getApplication(uri, id)
         },
         error: function() {
             alert("Failed to get application, url: " + url);
+        }
+    });
+}
+
+function loadApplicationActors(uri, application) {
+    var url = uri + '/application/' + application.id + '/actors';
+    console.log("getApplicationActors - url: " + url);
+    $.ajax({
+        uri: uri,
+        timeout: 20000,
+        beforeSend: function() {
+            startSpin();
+        },
+        complete: function() {
+            stopSpin();
+        },
+        dataType: 'json',
+        url: url,
+        type: 'GET',
+        success: function(data) {
+            if (data) {
+                console.log("getApplicationActors - Response: " + JSON.stringify(data));
+                application.actors = data;
+            } else {
+                console.log("getApplicationActors - Empty response");
+            }
+        },
+        error: function() {
+            alert("Failed to get application actors, url: " + url);
         }
     });
 }

--- a/calvin/actor/actor.py
+++ b/calvin/actor/actor.py
@@ -325,13 +325,14 @@ class Actor(object):
 
     # What are the arguments, really?
     def __init__(self, actor_type, name='', allow_invalid_transitions=True, disable_transition_checks=False,
-                 disable_state_checks=False, actor_id=None):
+                 disable_state_checks=False, actor_id=None, app_id=None):
         """Should _not_ be overridden in subclasses."""
         super(Actor, self).__init__()
         self._type = actor_type
         self.name = name  # optional: human_readable_name
         self.id = actor_id or calvinuuid.uuid("ACTOR")
         _log.debug("New actor id: %s, supplied actor id %s" % (self.id, actor_id))
+        self.app_id = app_id
         self._deployment_requirements = []
         self._signature = None
         self._component_members = set([self.id])  # We are only part of component if this is extended
@@ -548,6 +549,8 @@ class Actor(object):
             else:
                 state[key] = obj
 
+        state['app_id'] = self.app_id
+
         return state
 
     @verify_status([STATUS.LOADED, STATUS.READY, STATUS.PENDING])
@@ -648,12 +651,13 @@ class Actor(object):
 class ShadowActor(Actor):
     """A shadow actor try to behave as another actor but don't have any implementation"""
     def __init__(self, actor_type, name='', allow_invalid_transitions=True, disable_transition_checks=False,
-                 disable_state_checks=False, actor_id=None):
+                 disable_state_checks=False, actor_id=None, app_id=None):
         self.inport_names = []
         self.outport_names = []
         super(ShadowActor, self).__init__(actor_type, name, allow_invalid_transitions=allow_invalid_transitions, 
                                             disable_transition_checks=disable_transition_checks,
-                                            disable_state_checks=disable_state_checks, actor_id=actor_id)
+                                            disable_state_checks=disable_state_checks, actor_id=actor_id,
+                                            app_id=app_id)
 
     @manage(['_shadow_args'])
     def init(self, **args):

--- a/calvin/actorstore/tests/test_actors.py
+++ b/calvin/actorstore/tests/test_actors.py
@@ -220,9 +220,9 @@ class ActorTester(object):
 
         self.actor_names = actors
 
-    def instantiate_actor(self, actorclass, actorname):
+    def instantiate_actor(self, actorclass, actorname, app_id=None):
         try:
-            actor = actorclass(actorname, disable_state_checks=True)
+            actor = actorclass(actorname, app_id, disable_state_checks=True)
             if not hasattr(actor, 'test_set'):
                 self.actors[actorname] = 'no_test'
                 return

--- a/calvin/runtime/north/actormanager.py
+++ b/calvin/runtime/north/actormanager.py
@@ -40,7 +40,7 @@ class ActorManager(object):
         self.node = node
 
     def new(self, actor_type, args, state=None, prev_connections=None, connection_list=None, callback=None,
-            signature=None):
+            signature=None, app_id=None):
         """
         Instantiate an actor of type 'actor_type'. Parameters are passed in 'args',
         'name' is an optional parameter in 'args', specifying a human readable name.
@@ -58,9 +58,9 @@ class ActorManager(object):
 
         try:
             if state:
-                a = self._new_from_state(actor_type, state)
+                a = self._new_from_state(actor_type, state, app_id)
             else:
-                a = self._new(actor_type, args)
+                a = self._new(actor_type, args, app_id)
         except Exception as e:
             _log.exception("Actor creation failed")
             raise(e)
@@ -70,7 +70,7 @@ class ActorManager(object):
 
         self.actors[a.id] = a
 
-        self.node.storage.add_actor(a, self.node.id)
+        self.node.storage.add_actor(a, self.node.id, app_id)
 
         if prev_connections:
             # Convert prev_connections to connection_list format
@@ -88,7 +88,7 @@ class ActorManager(object):
             else:
                 return a.id
 
-    def _new_actor(self, actor_type, actor_id=None):
+    def _new_actor(self, app_id, actor_type, actor_id=None):
         """Return a 'bare' actor of actor_type, raises an exception on failure."""
         (found, is_primitive, class_) = ActorStore().lookup(actor_type)
         if not found:
@@ -102,7 +102,7 @@ class ActorManager(object):
             raise Exception("ERROR_NOT_FOUND")
         try:
             # Create a 'bare' instance of the actor
-            a = class_(actor_type, actor_id=actor_id)
+            a = class_(actor_type, actor_id=actor_id, app_id=app_id)
         except Exception as e:
             _log.exception("")
             _log.error("The actor %s(%s) can't be instantiated." % (actor_type, class_.__init__))
@@ -113,15 +113,14 @@ class ActorManager(object):
         except Exception as e:
             _log.exception("Catched new from state")
             _log.analyze(self.node.id, "+ FAILED REQS CREATE SHADOW ACTOR", {'class': class_})
-            a = ShadowActor(actor_type, actor_id=actor_id)
+            a = ShadowActor(actor_type, actor_id=actor_id, app_id=app_id)
             a._calvinsys = self.node.calvinsys()
         return a
 
-
-    def _new(self, actor_type, args):
+    def _new(self, actor_type, args, app_id):
         """Return an initialized actor in PENDING state, raises an exception on failure."""
         try:
-            a = self._new_actor(actor_type)
+            a = self._new_actor(app_id, actor_type)
             # Now that required APIs are attached we can call init() which may use the APIs
             human_readable_name = args.pop('name', '')
             a.name = human_readable_name
@@ -133,12 +132,11 @@ class ActorManager(object):
             raise(e)
         return a
 
-
-    def _new_from_state(self, actor_type, state):
+    def _new_from_state(self, actor_type, state, app_id):
         """Return a restored actor in PENDING state, raises an exception on failure."""
         try:
             _log.analyze(self.node.id, "+", state)
-            a = self._new_actor(actor_type, actor_id=state['id'])
+            a = self._new_actor(app_id, actor_type, actor_id=state['id'])
             if '_shadow_args' in state:
                 # We were a shadow, do a full init
                 args = state.pop('_shadow_args')
@@ -159,17 +157,25 @@ class ActorManager(object):
             raise(e)
         return a
 
-
-    def destroy(self, actor_id):
+    def delete_actor(self, actor_id):
         # @TOOD - check order here
         self.node.metering.remove_actor_info(actor_id)
         a = self.actors[actor_id]
         a.will_end()
         self.node.pm.remove_ports_of_actor(a)
+
         # @TOOD - insert callback here
         self.node.storage.delete_actor(actor_id)
         del self.actors[actor_id]
+
         self.node.control.log_actor_destroy(a.id)
+
+        self.node.storage.delete_actor_from_app(a.app_id, actor_id)
+        app = self.node.app_manager.applications.get(a.app_id)
+        if app:
+            app.remove_actor(actor_id)
+
+        return a
 
     # DEPRECATED: Enabling of an actor is dependent on wether it's connected or not
     def enable(self, actor_id):
@@ -235,7 +241,7 @@ class ActorManager(object):
             # This is a temporary fix by keep trying
             delay = 0.0 if actor._collect_placement_counter > actor._collect_placement_last_value + 100 else 0.2
             actor._collect_placement_counter += 1
-            actor._collect_placement_cb = async.DelayedCall(delay, self._update_requirements_placements, 
+            actor._collect_placement_cb = async.DelayedCall(delay, self._update_requirements_placements,
                                                     node_iter, actor_id, possible_placements, done=done,
                                                      move=move, cb=cb)
             return
@@ -259,7 +265,7 @@ class ActorManager(object):
             _log.analyze(self.node.id, "+ END", {})
         except:
             _log.exception("actormanager:_update_requirements_placements")
-        
+
 
     def migrate(self, actor_id, node_id, callback = None):
         """ Migrate an actor actor_id to peer node node_id """
@@ -293,12 +299,10 @@ class ActorManager(object):
         """ Actor disconnected, continue migration """
         if status:
             state = actor.state()
-            self.destroy(actor.id)
-            self.node.proto.actor_new(node_id, callback, actor_type, state, ports)
-        else:
-            # FIXME handle errors!!!
-            if callback:
-                callback(status=status)
+            self.delete_actor(actor.id)
+            self.node.proto.actor_new(node_id, callback, actor_type, state, ports, app_id=actor.app_id)
+        elif callback:  # FIXME handle errors!!!
+            callback(status=status)
 
     def peernew_to_local_cb(self, reply, **kwargs):
         if kwargs['actor_id'] == reply:

--- a/calvin/runtime/north/appmanager.py
+++ b/calvin/runtime/north/appmanager.py
@@ -65,9 +65,9 @@ class Application(object):
         actors = {v: [k] for k, v in self.actors.items() if v is not None}
         # Collect all actors under top component name
         components = {}
-        l = (len(ns)+1) if ns else 0 
+        l = (len(ns)+1) if ns else 0
         for name, _id in actors.iteritems():
-             if name.find(':',l)> -1:
+             if name.find(':', l) > -1:
                 # This is a component
                 # component name including optional namespace
                 component = ':'.join(name.split(':')[0:(2 if ns else 1)])
@@ -104,7 +104,7 @@ class Application(object):
 
     def group_components(self):
         self.components = {}
-        l = (len(self.ns)+1) if self.ns else 0 
+        l = (len(self.ns)+1) if self.ns else 0
         for name in self.actors.values():
              if name.find(':',l)> -1:
                 # This is part of a component
@@ -116,7 +116,7 @@ class Application(object):
                     self.components[component] = [name]
 
     def component_name(self, name):
-        l = (len(self.ns)+1) if self.ns else 0 
+        l = (len(self.ns)+1) if self.ns else 0
         if name.find(':',l)> -1:
             return ':'.join(name.split(':')[0:(2 if self.ns else 1)])
         else:
@@ -190,12 +190,15 @@ class AppManager(object):
         except:
             pass
         application.clear_node_info()
+        self.storage.get_application_actors(application.id, cb=CalvinCB(self._destroy_actors, application=application))
+
+    def _destroy_actors(self, key, value, application):
         # Loop over copy of app's actors, since modified inside loop
-        for actor_id in application.actors.keys()[:]:
+        for actor_id in value:
             if actor_id in self._node.am.list_actors():
                 _log.analyze(self._node.id, "+ LOCAL ACTOR", {'actor_id': actor_id})
-                # TODO: Check if it went ok
-                self._node.am.destroy(actor_id)
+                # TODO: Check if it whent ok
+                self._node.am.delete_actor(actor_id)
                 application.remove_actor(actor_id)
             else:
                 _log.analyze(self._node.id, "+ REMOTE ACTOR", {'actor_id': actor_id})
@@ -213,12 +216,11 @@ class AppManager(object):
         if value and 'node_id' in value:
             application.update_node_info(value['node_id'], key)
         else:
-            if retries<10:
+            if retries < 10:
                 # FIXME add backoff time
                 _log.analyze(self._node.id, "+ RETRY", {'actor_id': key, 'value': value, 'retries': retries})
-                self.storage.get_actor(key, CalvinCB(func=self._destroy_actor_cb, application=application, retries=(retries+1)))
+                self.storage.get_actor(key, CalvinCB(func=self._destroy_actor_cb, application=application, retries=(retries + 1)))
             else:
-                # FIXME report failure
                 _log.analyze(self._node.id, "+ GIVE UP", {'actor_id': key, 'value': value, 'retries': retries})
                 application.update_node_info(None, key)
 
@@ -270,7 +272,7 @@ class AppManager(object):
         reply = response.CalvinResponse(True)
         for actor_id in actor_ids:
             if actor_id in self._node.am.list_actors():
-                self._node.am.destroy(actor_id)
+                self._node.am.delete_actor(actor_id)
             else:
                 reply = response.CalvinResponse(False)
         if application_id in self.applications:
@@ -322,7 +324,7 @@ class AppManager(object):
     def execute_requirements(self, application_id, cb):
         """ Build dynops iterator to collect all possible placements,
             then trigger migration.
-            
+
             For initial deployment (all actors on the current node)
         """
         app = None
@@ -381,7 +383,7 @@ class AppManager(object):
             else:
                 try:
                     _log.analyze(self._node.id, "+ REQ OP", {'op': req['op'], 'kwargs': req['kwargs']})
-                    it = req_operations[req['op']].req_op(self._node, 
+                    it = req_operations[req['op']].req_op(self._node,
                                             actor_id=actor_id,
                                             component=actor.component_members(),
                                             **req['kwargs']).set_name(req['op']+",SActor"+actor_id)
@@ -404,7 +406,7 @@ class AppManager(object):
         union_iters = []
         for union_req in state['req']['requirements']:
             try:
-                union_iters.append(req_operations[union_req['op']].req_op(self._node, 
+                union_iters.append(req_operations[union_req['op']].req_op(self._node,
                                         actor_id=state['actor_id'],
                                         component=state['component'],
                                         **union_req['kwargs']).set_name(union_req['op']+",UActor"+state['actor_id']))
@@ -469,7 +471,7 @@ class AppManager(object):
         """ Matrix of weights between actors how close they want to be
             0 = don't care
             1 = same node
-            
+
             Currently any nodes that are connected gets 0.5, and
             diagonal is 1:s
         """
@@ -524,7 +526,7 @@ class AppManager(object):
                                                                    actor_id=actor_id, cb=cb))
             else:
                 _log.analyze(self._node.id, "+ OTHER NODE", {'actor_id': actor_id, 'actor_name': actor_name})
-                self.storage.get_actor(actor_id, cb=CalvinCB(self._migrate_from_rt, app=app, 
+                self.storage.get_actor(actor_id, cb=CalvinCB(self._migrate_from_rt, app=app,
                                                                   actor_id=actor_id, req=req,
                                                                   move=move, cb=cb))
 
@@ -580,7 +582,7 @@ class Deployer(object):
     # TODO Make deployer use the Application class group_components, component_name and get_req
     def group_components(self):
         self.components = {}
-        l = (len(self.ns)+1) if self.ns else 0 
+        l = (len(self.ns)+1) if self.ns else 0
         for name in self.deployable['actors']:
              if name.find(':',l)> -1:
                 # This is part of a component
@@ -592,7 +594,7 @@ class Deployer(object):
                     self.components[component] = [name]
 
     def component_name(self, name):
-        l = (len(self.ns)+1) if self.ns else 0 
+        l = (len(self.ns)+1) if self.ns else 0
         if name.find(':',l)> -1:
             return ':'.join(name.split(':')[0:(2 if self.ns else 1)])
         else:
@@ -603,7 +605,7 @@ class Deployer(object):
         name = name.split(':', 1)[1] if self.ns else name
         return self.deploy_info['requirements'][name] if (self.deploy_info and 'requirements' in self.deploy_info
                                                             and name in self.deploy_info['requirements']) else []
-        
+
     def instantiate(self, actor_name, actor_type, argd, signature=None):
         """
         Instantiate an actor.
@@ -629,7 +631,7 @@ class Deployer(object):
         # args is a **dictionary** of key-value arguments for this instance
         # signature is the GlobalStore actor-signature to lookup the actor
         args['name'] = actor_name
-        actor_id = self.node.am.new(actor_type=actor_type, args=args, signature=signature)
+        actor_id = self.node.am.new(actor_type=actor_type, args=args, signature=signature, app_id=self.app_id)
         if req:
             self.node.am.actors[actor_id].requirements_add(req, extend=False)
         return actor_id
@@ -823,6 +825,6 @@ class Deployer(object):
                 c = (src_actor, src_port, dst_actor, dst_port)
                 self.connectid(c)
 
-        self.node.app_manager.finalize(self.app_id, migrate=True if self.deploy_info else False, 
+        self.node.app_manager.finalize(self.app_id, migrate=True if self.deploy_info else False,
                                        cb=CalvinCB(self.cb, deployer=self))
 

--- a/calvin/runtime/north/calvin_node.py
+++ b/calvin/runtime/north/calvin_node.py
@@ -150,7 +150,8 @@ class Node(object):
     def new(self, actor_type, args, deploy_args=None, state=None, prev_connections=None, connection_list=None):
         # TODO requirements should be input to am.new
         actor_id = self.am.new(actor_type, args, state, prev_connections, connection_list,
-                        signature=deploy_args['signature'] if deploy_args and 'signature' in deploy_args else None)
+                               app_id=deploy_args['app_id'] if deploy_args else None,
+                               signature=deploy_args['signature'] if deploy_args and 'signature' in deploy_args else None)
         if deploy_args:
             app_id = deploy_args['app_id']
             if 'app_name' not in deploy_args:

--- a/calvin/runtime/north/calvin_proto.py
+++ b/calvin/runtime/north/calvin_proto.py
@@ -52,7 +52,7 @@ class CalvinTunnel(object):
                 self.tunnels[self.peer_node_id][self.id]=self
             else:
                 self.tunnels[self.peer_node_id] = {self.id: self}
-        # The callbacks recv for incoming message, down for tunnel failed or died, up for tunnel working 
+        # The callbacks recv for incoming message, down for tunnel failed or died, up for tunnel working
         self.recv_handler = None
         self.down_handler = None
         self.up_handler = None
@@ -99,7 +99,7 @@ class CalvinTunnel(object):
             _log.error("Got none ack on destruction of tunnel!\n%s" % reply)
 
     def send(self, payload):
-        """ Send a payload over the tunnel 
+        """ Send a payload over the tunnel
             payload must be serializable, i.e. only built-in types such as:
             dict, list, tuple, string, numbers, booleans, etc
         """
@@ -126,7 +126,7 @@ class CalvinTunnel(object):
     def close(self, local_only=False):
         """ Removes the tunnel but does not inform
             other end when local_only.
-            
+
             Currently does not support local_only == False
         """
         self.status = CalvinTunnel.STATUS.TERMINATED
@@ -138,7 +138,7 @@ class CalvinTunnel(object):
 class CalvinProto(CalvinCBClass):
     """ CalvinProto class is the interface between runtimes for all runtime
         subsystem that need to interact. It uses the links in network.
-        
+
         Besides handling tunnel setup etc, it mainly formats commands uniformerly.
     """
 
@@ -201,8 +201,8 @@ class CalvinProto(CalvinCBClass):
 
     #### ACTORS ####
 
-    def actor_new(self, to_rt_uuid, callback, actor_type, state, prev_connections):
-        """ Creates a new actor on to_rt_uuid node, but is only intended for migrating actors 
+    def actor_new(self, to_rt_uuid, callback, actor_type, state, prev_connections, app_id):
+        """ Creates a new actor on to_rt_uuid node, but is only intended for migrating actors
             callback: called when finished with the peers respons as argument
             actor_type: see actor manager
             state: see actor manager
@@ -213,15 +213,21 @@ class CalvinProto(CalvinCBClass):
                                                         callback=callback,
                                                         actor_type=actor_type,
                                                         state=state,
-                                                        prev_connections=prev_connections)):
+                                                        prev_connections=prev_connections,
+                                                        app_id=app_id)):
             # Already have link just continue in _actor_new
-                self._actor_new(to_rt_uuid, callback, actor_type, state, prev_connections, status=response.CalvinResponse(True))
+                self._actor_new(to_rt_uuid, callback, actor_type, state, prev_connections, app_id=app_id, status=response.CalvinResponse(True))
 
-    def _actor_new(self, to_rt_uuid, callback, actor_type, state, prev_connections, status, peer_node_id=None, uri=None):
+    def _actor_new(self, to_rt_uuid, callback, actor_type, state, prev_connections, status, app_id, peer_node_id=None, uri=None):
         """ Got link? continue actor new """
         if status:
             msg = {'cmd': 'ACTOR_NEW',
-                   'state':{'actor_type': actor_type, 'actor_state': state, 'prev_connections':prev_connections}}
+                   'state': {
+                       'actor_type': actor_type,
+                       'actor_state': state,
+                       'prev_connections': prev_connections,
+                       'app_id': app_id
+                   }}
             self.network.links[to_rt_uuid].send_with_reply(callback, msg)
         elif callback:
             callback(status=status)
@@ -233,6 +239,7 @@ class CalvinProto(CalvinCBClass):
                          None,
                          payload['state']['actor_state'],
                          payload['state']['prev_connections'],
+                         app_id=payload['state']['app_id'],
                          callback=CalvinCB(self._actor_new_handler, payload))
 
     def _actor_new_handler(self, payload, status, **kwargs):
@@ -241,7 +248,7 @@ class CalvinProto(CalvinCBClass):
         self.network.links[payload['from_rt_uuid']].send(msg)
 
     def actor_migrate(self, to_rt_uuid, callback, actor_id, requirements, extend=False, move=False):
-        """ Request actor on to_rt_uuid node to migrate accoring to new deployment requirements 
+        """ Request actor on to_rt_uuid node to migrate accoring to new deployment requirements
             callback: called when finished with the status respons as argument
             actor_id: actor_id to migrate
             requirements: see app manager
@@ -256,7 +263,7 @@ class CalvinProto(CalvinCBClass):
                                                         extend=extend,
                                                         move=move)):
             # Already have link just continue in _actor_new
-                self._actor_migrate(to_rt_uuid, callback, actor_id, requirements, 
+                self._actor_migrate(to_rt_uuid, callback, actor_id, requirements,
                                     extend, move, status=response.CalvinResponse(True))
 
     def _actor_migrate(self, to_rt_uuid, callback, actor_id, requirements, extend, move, status,
@@ -308,7 +315,7 @@ class CalvinProto(CalvinCBClass):
 
     def app_destroy_handler(self, payload):
         """ Peer request destruction of app and its actors """
-        reply = self.node.app_manager.destroy_request(payload['app_uuid'], 
+        reply = self.node.app_manager.destroy_request(payload['app_uuid'],
                                                       payload['actor_uuids'] if 'actor_uuids' in payload else [])
         msg = {'cmd': 'REPLY', 'msg_uuid': payload['msg_uuid'], 'value': reply.encode()}
         self.network.links[payload['from_rt_uuid']].send(msg)
@@ -338,7 +345,7 @@ class CalvinProto(CalvinCBClass):
             tunnel = CalvinTunnel(self.network.links, self.tunnels, None, tunnel_type, policy, rt_id=self.node.id)
             self.network.link_request(to_rt_uuid, CalvinCB(self._tunnel_link_request_finished, tunnel=tunnel, to_rt_uuid=to_rt_uuid, tunnel_type=tunnel_type, policy=policy))
             return tunnel
-        
+
         # Do we have a tunnel already?
         tunnel = self._get_tunnel(to_rt_uuid, tunnel_type = tunnel_type)
         if tunnel != None:
@@ -472,7 +479,7 @@ class CalvinProto(CalvinCBClass):
             tunnel.recv_handler(payload['value'])
         except Exception as e:
             _log.exception("Check error in tunnel recv handler")
-            _log.analyze(self.rt_id, "+ EXCEPTION TUNNEL RECV HANDLER", {'payload': payload, 'exception': str(e)}, 
+            _log.analyze(self.rt_id, "+ EXCEPTION TUNNEL RECV HANDLER", {'payload': payload, 'exception': str(e)},
                                                                 peer_node_id=payload['from_rt_uuid'], tb=True)
 
     #### PORTS ####

--- a/calvin/runtime/north/metering.py
+++ b/calvin/runtime/north/metering.py
@@ -59,6 +59,8 @@ class Metering(object):
         self.actors_aggregated_time = {}
 
     def fired(self, actor_id, action_name):
+        if actor_id not in self.actors_meta:
+            return
         t = time.time()
         if self.aggregated_timeout > 0.0:
             # Aggregate

--- a/calvin/tests/test_actormanager.py
+++ b/calvin/tests/test_actormanager.py
@@ -28,6 +28,7 @@ class DummyNode:
         self.storage = mock.Mock()
         self.control = mock.Mock()
         self.metering = metering.set_metering(metering.Metering(self))
+        self.app_manager = mock.Mock()
 
     def calvinsys(self):
         return None
@@ -43,8 +44,8 @@ class ActorManagerTests(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def _new_actor(self, a_type, a_args, **kwargs):
-        a_id = self.am.new(a_type, a_args, **kwargs)
+    def _new_actor(self, a_type, a_args, app_id=None, **kwargs):
+        a_id = self.am.new(a_type, a_args, app_id=app_id, **kwargs)
         a = self.am.actors.get(a_id, None)
         self.assertTrue(a)
         return a, a_id
@@ -76,7 +77,7 @@ class ActorManagerTests(unittest.TestCase):
         a.data = 43
         a.n = 2
         s = a.state()
-        self.am.destroy(a_id)
+        self.am.delete_actor(a_id)
         self.assertEqual(len(self.am.actors), 0)
 
         b, b_id = self._new_actor(a_type, None, state = s)

--- a/calvin/utilities/utils.py
+++ b/calvin/utilities/utils.py
@@ -282,6 +282,13 @@ def get_application(rt, application_id, timeout=TIMEOUT, async=False):
     return check_response(r)
 
 
+def get_application_actors(rt, application_id, timeout=TIMEOUT, async=False):
+    rt = get_RT(rt)
+    req = session if async else requests
+    r = req.get(rt.control_uri + '/application/{}/actors'.format(application_id), timeout=timeout)
+    return check_response(r)
+
+
 def delete_application(rt, application_id, timeout=TIMEOUT, async=False):
     rt = get_RT(rt)
     req = session if async else requests
@@ -381,7 +388,7 @@ g = None
 f = None
 from functools import partial
 for g, f in globals().iteritems():
-    if hasattr(f, '__call__') and ((hasattr(f, '__code__') and 'async' in f.__code__.co_varnames) 
+    if hasattr(f, '__call__') and ((hasattr(f, '__code__') and 'async' in f.__code__.co_varnames)
                                     or f.__name__ == 'peer_setup'):
         funcs['async_'+g] = partial(f, async=True)
 globals().update(funcs)


### PR DESCRIPTION
When deleting an actor, it is not removed from the application's list of actors in the storage.

To reproduce:
csruntime --host localhost --port 5001 --controlport 5002 --keep-alive -l INFO
cscontrol http://localhost:5002 deploy calvin/examples/sample-scripts/actions.calvin
cscontrol http://localhost:5002 actor delete <actor_id>
csweb
Then, if you select the application in the web interface, you'll get an error because the actor id is still in the application's list of actors, so it will try to fetch that actor, but since it no longer exists, it'll fail.
