### PR TITLE
On peer setup, call peer setup for peer nodes as well

### DIFF
--- a/calvin/runtime/north/calvin_proto.py
+++ b/calvin/runtime/north/calvin_proto.py
@@ -52,7 +52,7 @@ class CalvinTunnel(object):
                 self.tunnels[self.peer_node_id][self.id]=self
             else:
                 self.tunnels[self.peer_node_id] = {self.id: self}
-        # The callbacks recv for incoming message, down for tunnel failed or died, up for tunnel working 
+        # The callbacks recv for incoming message, down for tunnel failed or died, up for tunnel working
         self.recv_handler = None
         self.down_handler = None
         self.up_handler = None
@@ -99,7 +99,7 @@ class CalvinTunnel(object):
             raise Exception("Got none ack on destruction of tunnel!\n%s" % reply)
 
     def send(self, payload):
-        """ Send a payload over the tunnel 
+        """ Send a payload over the tunnel
             payload must be serializable, i.e. only built-in types such as:
             dict, list, tuple, string, numbers, booleans, etc
         """
@@ -126,7 +126,7 @@ class CalvinTunnel(object):
     def close(self, local_only=False):
         """ Removes the tunnel but does not inform
             other end when local_only.
-            
+
             Currently does not support local_only == False
         """
         self.status = CalvinTunnel.STATUS.TERMINATED
@@ -138,7 +138,7 @@ class CalvinTunnel(object):
 class CalvinProto(CalvinCBClass):
     """ CalvinProto class is the interface between runtimes for all runtime
         subsystem that need to interact. It uses the links in network.
-        
+
         Besides handling tunnel setup etc, it mainly formats commands uniformerly.
     """
 
@@ -156,6 +156,7 @@ class CalvinProto(CalvinCBClass):
             'PORT_PENDING_MIGRATE': [CalvinCB(self.not_impl_handler)],
             'PORT_COMMIT_MIGRATE': [CalvinCB(self.not_impl_handler)],
             'PORT_CANCEL_MIGRATE': [CalvinCB(self.not_impl_handler)],
+            'PEER_SETUP': [CalvinCB(self.peer_setup_handler)],
             'TUNNEL_NEW': [CalvinCB(self.tunnel_new_handler)],
             'TUNNEL_DESTROY': [CalvinCB(self.tunnel_destroy_handler)],
             'TUNNEL_DATA': [CalvinCB(self.tunnel_data_handler)],
@@ -202,7 +203,7 @@ class CalvinProto(CalvinCBClass):
     #### ACTORS ####
 
     def actor_new(self, to_rt_uuid, callback, actor_type, state, prev_connections):
-        """ Creates a new actor on to_rt_uuid node, but is only intended for migrating actors 
+        """ Creates a new actor on to_rt_uuid node, but is only intended for migrating actors
             callback: called when finished with the peers respons as argument
             actor_type: see actor manager
             state: see actor manager
@@ -241,7 +242,7 @@ class CalvinProto(CalvinCBClass):
         self.network.links[payload['from_rt_uuid']].send(msg)
 
     def actor_migrate(self, to_rt_uuid, callback, actor_id, requirements, extend=False, move=False):
-        """ Request actor on to_rt_uuid node to migrate accoring to new deployment requirements 
+        """ Request actor on to_rt_uuid node to migrate accoring to new deployment requirements
             callback: called when finished with the status respons as argument
             actor_id: actor_id to migrate
             requirements: see app manager
@@ -256,7 +257,7 @@ class CalvinProto(CalvinCBClass):
                                                         extend=extend,
                                                         move=move)):
             # Already have link just continue in _actor_new
-                self._actor_migrate(to_rt_uuid, callback, actor_id, requirements, 
+                self._actor_migrate(to_rt_uuid, callback, actor_id, requirements,
                                     extend, move, status=response.CalvinResponse(True))
 
     def _actor_migrate(self, to_rt_uuid, callback, actor_id, requirements, extend, move, status,
@@ -308,7 +309,7 @@ class CalvinProto(CalvinCBClass):
 
     def app_destroy_handler(self, payload):
         """ Peer request destruction of app and its actors """
-        reply = self.node.app_manager.destroy_request(payload['app_uuid'], 
+        reply = self.node.app_manager.destroy_request(payload['app_uuid'],
                                                       payload['actor_uuids'] if 'actor_uuids' in payload else [])
         msg = {'cmd': 'REPLY', 'msg_uuid': payload['msg_uuid'], 'value': reply.encode()}
         self.network.links[payload['from_rt_uuid']].send(msg)
@@ -338,7 +339,7 @@ class CalvinProto(CalvinCBClass):
             tunnel = CalvinTunnel(self.network.links, self.tunnels, None, tunnel_type, policy, rt_id=self.node.id)
             self.network.link_request(to_rt_uuid, CalvinCB(self._tunnel_link_request_finished, tunnel=tunnel, to_rt_uuid=to_rt_uuid, tunnel_type=tunnel_type, policy=policy))
             return tunnel
-        
+
         # Do we have a tunnel already?
         tunnel = self._get_tunnel(to_rt_uuid, tunnel_type = tunnel_type)
         if tunnel != None:
@@ -472,7 +473,7 @@ class CalvinProto(CalvinCBClass):
             tunnel.recv_handler(payload['value'])
         except Exception as e:
             _log.exception("Check error in tunnel recv handler")
-            _log.analyze(self.rt_id, "+ EXCEPTION TUNNEL RECV HANDLER", {'payload': payload, 'exception': str(e)}, 
+            _log.analyze(self.rt_id, "+ EXCEPTION TUNNEL RECV HANDLER", {'payload': payload, 'exception': str(e)},
                                                                 peer_node_id=payload['from_rt_uuid'], tb=True)
 
     #### PORTS ####
@@ -507,6 +508,35 @@ class CalvinProto(CalvinCBClass):
         # Send reply
         msg = {'cmd': 'REPLY', 'msg_uuid': payload['msg_uuid'], 'value': reply.encode()}
         self.network.links[payload['from_rt_uuid']].send(msg)
+
+    #### NODES ####
+
+    def peer_setup(self, to_rt_uuid, peers, callback=None):
+        """ Sends a peer setup request to the other node.
+            prev_connections: list of node ids to setup a connecting with
+        """
+        if self.node.network.link_request(to_rt_uuid, CalvinCB(self._peer_setup, callback=callback, peers=peers)):
+            # Already have link just continue in _actor_new
+                self._peer_setup(to_rt_uuid, callback, peers, status=response.CalvinResponse(True))
+
+    def _peer_setup(self, to_rt_uuid, callback, peers, status):
+        """ Got link? continue actor new """
+        if status:
+            msg = {'cmd': 'PEER_SETUP',
+                   'peers': peers}
+            self.network.links[to_rt_uuid].send_with_reply(callback, msg)
+        elif callback:
+            callback(status=status)
+
+    def peer_setup_handler(self, payload):
+        """ Peer request new actor with state and connections """
+        self.node.peersetup(payload['peers'], cb=CalvinCB(self._peer_setup_handler, payload))
+
+    def _peer_setup_handler(self, payload, status, **kwargs):
+        """ Potentially created actor, reply to requesting node """
+        msg = {'cmd': 'REPLY', 'msg_uuid': payload['msg_uuid'], 'value': status.encode()}
+        self.network.links[payload['from_rt_uuid']].send(msg)
+
 
 if __name__ == '__main__':
     import pytest

--- a/calvin/runtime/north/calvin_proto.py
+++ b/calvin/runtime/north/calvin_proto.py
@@ -516,7 +516,7 @@ class CalvinProto(CalvinCBClass):
             prev_connections: list of node ids to setup a connecting with
         """
         if self.node.network.link_request(to_rt_uuid, CalvinCB(self._peer_setup, callback=callback, peers=peers)):
-            # Already have link just continue in _actor_new
+            # Already have link just continue in _peer_setup
                 self._peer_setup(to_rt_uuid, callback, peers, status=response.CalvinResponse(True))
 
     def _peer_setup(self, to_rt_uuid, callback, peers, status):

--- a/calvin/runtime/north/calvincontrol.py
+++ b/calvin/runtime/north/calvincontrol.py
@@ -876,7 +876,12 @@ class CalvinControl(object):
         else:
             data = {k: (v[0], v[1].status) for k, v in peer_node_ids.items()}
 
-        peers = data.keys()
+        peers = []
+        for uri, (_, status_code) in data.iteritems():
+            # Only include successful peers
+            if status_code == 200:
+                peers.append(uri)
+
         for uri, (node_id, status_code) in data.iteritems():
             if status_code == 200:
                 to_send = set(peers)

--- a/calvin/tests/test_calvin.py
+++ b/calvin/tests/test_calvin.py
@@ -61,13 +61,15 @@ runtime = None
 runtimes = []
 peerlist = []
 kill_peers = True
+ip_addr = None
+
 
 def setup_module(module):
     global runtime
     global runtimes
     global peerlist
     global kill_peers
-    ip_addr = None
+    global ip_addr
     bt_master_controluri = None
 
     try:
@@ -856,3 +858,36 @@ class TestCalvinScript(CalvinTestBase):
 
         for actor in d.actor_map.values():
             assert actor not in actors
+
+
+@pytest.mark.essential
+@pytest.mark.slow
+class TestPeerSetup(CalvinTestBase):
+
+    def testPeerSetup(self):
+        global ip_addr
+        rt1, _ = dispatch_node(["calvinip://%s:5010" % (ip_addr, )], "http://localhost:5011")
+        rt2, _ = dispatch_node(["calvinip://%s:5012" % (ip_addr, )], "http://localhost:5013")
+        rt3, _ = dispatch_node(["calvinip://%s:5014" % (ip_addr, )], "http://localhost:5015")
+
+        peers = [rt2.uri[0], rt3.uri[0]]
+        utils.peer_setup(rt1, peers)
+
+        time.sleep(0.5)
+
+        rt1_nodes = utils.get_nodes(rt1)
+        rt2_nodes = utils.get_nodes(rt2)
+        rt3_nodes = utils.get_nodes(rt3)
+
+        for peer in [rt1, rt2, rt3]:
+            utils.quit(peer)
+            time.sleep(0.2)
+
+        assert rt2.id in rt1_nodes
+        assert rt3.id in rt1_nodes
+
+        assert rt1.id in rt2_nodes
+        assert rt3.id in rt2_nodes
+
+        assert rt1.id in rt3_nodes
+        assert rt2.id in rt3_nodes

--- a/calvin/tests/test_calvin2.py
+++ b/calvin/tests/test_calvin2.py
@@ -144,8 +144,6 @@ def setup_module(module):
         rt3,_ = dispatch_node(["calvinip://%s:5002" % (ip_addr,)], "http://localhost:5005")
         time.sleep(.4)
         utils.peer_setup(rt1, ["calvinip://%s:5001" % (ip_addr,), "calvinip://%s:5002" % (ip_addr, )])
-        utils.peer_setup(rt2, ["calvinip://%s:5000" % (ip_addr,), "calvinip://%s:5002" % (ip_addr, )])
-        utils.peer_setup(rt3, ["calvinip://%s:5000" % (ip_addr,), "calvinip://%s:5001" % (ip_addr, )])
         time.sleep(.4)
 
 


### PR DESCRIPTION
This commit avoids having to do multiple peer setup, for example like it's done in test_calvin2.py
        utils.peer_setup(rt1, ["calvinip://%s:5001" % (ip_addr,), "calvinip://%s:5002" % (ip_addr, )])
        utils.peer_setup(rt2, ["calvinip://%s:5000" % (ip_addr,), "calvinip://%s:5002" % (ip_addr, )])
        utils.peer_setup(rt3, ["calvinip://%s:5000" % (ip_addr,), "calvinip://%s:5001" % (ip_addr, )])
This results in the following behaviour:
calvin-base(develop)$ csruntime --host localhost --port 5001 --controlport 5002 --keep-alive
calvin-base(develop)$ csruntime --host localhost --port 5003 --controlport 5004 --keep-alive
calvin-base(develop)$ csruntime --host localhost --port 5005 --controlport 5006 --keep-alive
calvin-base(develop)$ cscontrol http://localhost:5002 nodes add calvinip://localhost:5003 calvinip://localhost:5005
{u'calvinip://localhost:5005': [u'80c3bc0f-0164-4cd4-a6cb-da4e2cdccaa9', 200], u'calvinip://localhost:5003': [u'c6b187c9-5858-47ad-91a8-52ff0cd97bca', 200]}
calvin-base(develop)$ cscontrol http://localhost:5002 nodes list
[u'80c3bc0f-0164-4cd4-a6cb-da4e2cdccaa9', u'c6b187c9-5858-47ad-91a8-52ff0cd97bca']
calvin-base(develop)$ cscontrol http://localhost:5004 nodes list
[u'cd9bc012-13cd-4746-b65a-6e01d8388501']
calvin-base(develop)$ cscontrol http://localhost:5006 nodes list
[u'cd9bc012-13cd-4746-b65a-6e01d8388501']

Instead, we use proto to call peer_setup for each of the nodes we add. The result if the following:
(same setup with 3 runtimes)
calvin-base(peer-setup)$ cscontrol http://localhost:5002 nodes add calvinip://localhost:5003 calvinip://localhost:5005
{u'calvinip://localhost:5005': [u'8d1df665-12c1-425b-af9e-7f739833ca6e', 200], u'calvinip://localhost:5003': [u'08be4b54-9813-40d6-8e4b-0ba347e4fe8e', 200]}
calvin-base(peer-setup)$ cscontrol http://localhost:5002 nodes list
[u'08be4b54-9813-40d6-8e4b-0ba347e4fe8e', u'8d1df665-12c1-425b-af9e-7f739833ca6e']
calvin-base(peer-setup)$ cscontrol http://localhost:5004 nodes list
[u'a9dac5c7-88d3-4389-ab02-bf518c59068e', u'8d1df665-12c1-425b-af9e-7f739833ca6e']
calvin-base(peer-setup)$ cscontrol http://localhost:5006 nodes list
[u'a9dac5c7-88d3-4389-ab02-bf518c59068e', u'08be4b54-9813-40d6-8e4b-0ba347e4fe8e']

Now node 5004 knows about both 5002 and 5006, not only 5002 as it would have before this change. Same for 5006.
