### PR TITLE
return value from storage without callback function

### DIFF
--- a/calvin/runtime/north/calvin_node.py
+++ b/calvin/runtime/north/calvin_node.py
@@ -218,6 +218,7 @@ def create_node(uri, control_uri, attributes=None):
     n = Node(uri, control_uri, attributes)
     n.run()
     _log.info('Quitting node "%s"' % n.uri)
+    return n
 
 
 def create_tracing_node(uri, control_uri, attributes=None):
@@ -242,6 +243,7 @@ def create_tracing_node(uri, control_uri, attributes=None):
             tracer.runfunc(n.run)
         sys.stdout = tmp
     _log.info('Quitting node "%s"' % n.uri)
+    return n
 
 
 def start_node(uri, control_uri, trace_exec=False, attributes=None):

--- a/calvin/runtime/north/storage.py
+++ b/calvin/runtime/north/storage.py
@@ -200,13 +200,13 @@ class Storage(object):
     def get(self, prefix, key, cb=None):
         """ Get value for key: prefix+key, first look in localstore
         """
-        cb = cb if cb else CalvinCB(self.get_cb, org_cb=cb, org_key=key)
         value = None
         if prefix + key in self.localstore:
             value = self.localstore[prefix + key]
             if value:
                 value = self.coder.decode(value)
-            async.DelayedCall(0, cb, key=key, value=value)
+            if cb:
+                async.DelayedCall(0, cb, key=key, value=value)
         elif self.started:
             try:
                 return self.storage.get(key=prefix + key, cb=CalvinCB(func=self.get_cb, org_cb=cb, org_key=key))
@@ -271,7 +271,6 @@ class Storage(object):
             storage and hence the return list might contain removed items,
             but also missing items.
         """
-        cb = cb if cb else CalvinCB(self.get_concat_cb, org_cb=None, org_key=key, local_list=[])
         value = []
         if prefix + key in self.localstore_sets:
             _log.analyze(self.node.id, "+ GET LOCAL", None)
@@ -354,7 +353,6 @@ class Storage(object):
     def append(self, prefix, key, value, cb=None):
         """ set operation append on key: prefix+key value: value is a list of items
         """
-        cb = cb if cb else CalvinCB(self.append_cb, org_key=prefix + key, org_value=value, org_cb=None)
         _log.debug("Append key %s, value %s" % (prefix + key, value))
         # Keep local storage for sets updated until confirmed
         if (prefix + key) in self.localstore_sets:

--- a/calvin/tests/test_storage.py
+++ b/calvin/tests/test_storage.py
@@ -1,0 +1,116 @@
+import os
+import unittest
+
+from calvin.runtime.north.calvin_node import Node
+from calvin.runtime.north.appmanager import Application
+from calvin.runtime.north.actormanager import ActorManager
+
+
+class TestStorage(unittest.TestCase):
+
+    def setUp(self):
+        ip_addr = None
+        try:
+            ip_addr = os.environ["CALVIN_TEST_LOCALHOST"]
+        except:
+            import socket
+            ip_addr = socket.gethostbyname(socket.gethostname())
+
+        self.uri = "calvinip://%s:%s" % (ip_addr, 5000)
+        self.control_uri = "http://%s:%s" % (ip_addr, 5001)
+        self.node = Node(self.uri, self.control_uri)
+        self.storage = self.node.storage
+        self.storage.start()
+
+    def test_set_get(self):
+        self.storage.set("test-prefix-", "test-key", "my_value")
+        assert self.storage.get("test-prefix-", "test-key") == "my_value"
+
+    def test_get_iter(self):
+        self.storage.set("test-iter-prefix-", "test-iter-key", "my_value")
+        assert self.storage.get_iter("test-iter-prefix-", "test-iter-key", []) == "my_value"
+
+    def test_append(self):
+        self.storage.append("test-append-prefix-", "test-append-key", ["my_value"])
+        assert self.storage.get_concat("test-append-prefix-", "test-append-key") == ["my_value"]
+
+    def test_remove(self):
+        self.storage.append("test-remove-prefix-", "test-remove-key", ["my_value"])
+        assert self.storage.get_concat("test-remove-prefix-", "test-remove-key") == ["my_value"]
+        self.storage.remove("test-remove-prefix-", "test-remove-key", ["my_value"])
+        assert self.storage.get_concat("test-remove-prefix-", "test-remove-key") == []
+
+    def test_delete(self):
+        self.storage.set("test-delete-prefix-", "test-delete-key", "my_value")
+        assert self.storage.get("test-delete-prefix-", "test-delete-key") == "my_value"
+        self.storage.delete("test-delete-prefix-", "test-delete-key")
+        assert self.storage.get("test-delete-prefix-", "test-delete-key") == None
+
+    def test_store_node(self):
+        self.storage.add_node(self.node)
+        value = self.storage.get_node(self.node.id)
+        assert value['uri'] == self.uri
+        assert value['control_uri'] == self.control_uri
+
+        self.storage.delete_node(self.node)
+        assert self.storage.get_node(self.node.id) == None
+
+    def test_application(self):
+        actor_manager = ActorManager(self.node)
+        actors = {
+            'actor-123': 'actor:src',
+            'actor-456': 'actor:snk'
+        }
+        application = Application("123", "my_app", self.node.id, actor_manager, actors=actors)
+        self.storage.add_application(application)
+
+        value = self.storage.get_application(application.id)
+        assert value == {
+            'actors': ['actor-456', 'actor-123'],
+            'ns': 'my_app',
+            'actors_name_map': {'actor-456': 'actor:snk', 'actor-123': 'actor:src'},
+            'name': 'my_app',
+            'origin_node_id': self.node.id
+        }
+
+        self.storage.delete_application(application.id)
+        assert self.storage.get_application(application.id) == None
+
+    def test_actor(self):
+        actor_manager = ActorManager(self.node)
+        actor_id = actor_manager.new('std.Identity', {'name': 'identity'})
+        actor = actor_manager.actors[actor_id]
+
+        self.storage.add_actor(actor, self.node.id)
+        value = self.storage.get_actor(actor.id)
+        assert value == {
+            'inports': [{'id': actor.inports['token'].id, 'name': 'token'}],
+            'outports': [{u'id': actor.outports['token'].id, 'name': 'token'}],
+            'is_shadow': False,
+            'name': 'identity',
+            'node_id': self.node.id,
+            'type': 'std.Identity'
+        }
+
+        self.storage.delete_actor(actor.id)
+        assert self.storage.get_actor(actor.id) == None
+
+    def test_port(self):
+        actor_manager = ActorManager(self.node)
+        actor_id = actor_manager.new('std.Identity', {'name': 'identity'})
+        actor = actor_manager.actors[actor_id]
+        port = actor.inports['token']
+
+        self.storage.add_port(port, self.node.id)
+        value = self.storage.get_port(port.id)
+        assert value == {
+            'actor_id': actor.id,
+            'connected': False,
+            'direction': 'in',
+            'name': 'token',
+            'node_id': self.node.id,
+            'peer': None
+        }
+
+        self.storage.delete_port(port.id)
+        assert self.storage.get_port(port.id) == None


### PR DESCRIPTION
Storage now returns value in get functions. This allows for
**value = storage.get(...)**
instead of:
**storage.get(..., cb=foo)
def foo(key, value, ...):**