### PR TITLE
fix storage runtime

### DIFF
--- a/calvin/runtime/north/calvin_network.py
+++ b/calvin/runtime/north/calvin_network.py
@@ -179,6 +179,8 @@ class CalvinNetwork(object):
         """
         if not uris:
             uris = [schema + ":default" for schema in self.transports.keys()]
+        if not isinstance(uris, list):
+            uris = [uris]
 
         for uri in uris:
             schema, addr = uri.split(':', 1)

--- a/calvin/runtime/north/calvin_node.py
+++ b/calvin/runtime/north/calvin_node.py
@@ -57,7 +57,7 @@ class Node(object):
        such as name of node
     """
 
-    def __init__(self, uri, control_uri, attributes=None):
+    def __init__(self, uri, control_uri, attributes=None, self_start=True):
         super(Node, self).__init__()
         self.uri = uri
         self.control_uri = control_uri
@@ -87,7 +87,8 @@ class Node(object):
         self.app_manager = appmanager.AppManager(self)
 
         # The initialization that requires the main loop operating is deferred to start function
-        async.DelayedCall(0, self.start)
+        if self_start:
+            async.DelayedCall(0, self.start)
 
     def insert_local_reply(self):
         msg_id = calvinuuid.uuid("LMSG")

--- a/calvin/tests/test_nodecontrol.py
+++ b/calvin/tests/test_nodecontrol.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mock import patch
 
 from calvin.utilities import nodecontrol
@@ -50,3 +52,21 @@ def test_dispatch_storage_node(get_node_id, start_node):
     nodecontrol.dispatch_storage_node(URI, CONTROL_URI, trace=True, attributes={})
     start_node.assert_called_with(URI, CONTROL_URI, True, {})
     assert get_node_id.called
+
+
+@pytest.mark.slow
+@patch('calvin.utilities.nodecontrol.get_node_id')
+def test_node_control_barrier(get_node_id):
+    get_node_id.side_effect = Exception("")  # return_value = None
+    nodecontrol.node_control(CONTROL_URI, barrier=False)
+    assert not get_node_id.called
+
+    with pytest.raises(AssertionError):
+        nodecontrol.node_control(CONTROL_URI, barrier=True)
+    assert get_node_id.call_count == 20
+    get_node_id.reset_mock()
+
+    get_node_id.side_effect = None
+    get_node_id.return_value = 1
+    nodecontrol.node_control(CONTROL_URI, barrier=True)
+    assert get_node_id.call_count == 1

--- a/calvin/tests/test_nodecontrol.py
+++ b/calvin/tests/test_nodecontrol.py
@@ -1,0 +1,52 @@
+from mock import patch
+
+from calvin.utilities import nodecontrol
+
+URI = "http://localhost:5001"
+CONTROL_URI = "http://localhost:5002"
+
+
+@patch('calvin.runtime.north.calvin_node.create_tracing_node')
+@patch('calvin.runtime.north.calvin_node.create_node')
+def test_start_node(create_node, create_tracing_node):
+    nodecontrol.start_node(URI, CONTROL_URI, attributes={'a': 1})
+    create_node.assert_called_with(URI, CONTROL_URI, {'a': 1})
+    assert not create_tracing_node.called
+
+    create_node.reset_mock()
+    nodecontrol.start_node(URI, CONTROL_URI, trace=True, attributes={'a': 1})
+    create_tracing_node.assert_called_with(URI, CONTROL_URI, True, {'a': 1})
+    assert not create_node.called
+
+
+@patch('calvin.runtime.north.calvin_node.Node.run')
+def test_start_node_runs_node(run):
+    nodecontrol.start_node(URI, CONTROL_URI, attributes={'a': 1})
+    assert run.called
+
+
+@patch('calvin.utilities.nodecontrol.get_node_id')
+@patch('calvin.runtime.north.calvin_node.start_node')
+def test_dispatch_node(start_node, get_node_id):
+    nodecontrol.dispatch_node(URI, CONTROL_URI, attributes={'a': 1}, barrier=False)
+    assert start_node.called
+    assert not get_node_id.called
+
+    start_node.reset_mock()
+    nodecontrol.dispatch_node(URI, CONTROL_URI, attributes={'a': 1}, barrier=True)
+    assert start_node.called
+    assert get_node_id.called
+
+
+@patch('calvin.utilities.storage_node.StorageNode.run')
+def test_start_storage_node(run):
+    nodecontrol.start_storage_node(URI, CONTROL_URI)
+    assert run.called
+
+
+@patch('calvin.utilities.storage_node.start_node')
+@patch('calvin.utilities.nodecontrol.get_node_id')
+def test_dispatch_storage_node(get_node_id, start_node):
+    nodecontrol.dispatch_storage_node(URI, CONTROL_URI, trace=True, attributes={})
+    start_node.assert_called_with(URI, CONTROL_URI, True, {})
+    assert get_node_id.called

--- a/calvin/tests/test_requirements.py
+++ b/calvin/tests/test_requirements.py
@@ -29,6 +29,7 @@ from calvin.utilities.attribute_resolver import format_index_string
 from calvin.Tools.cscontrol import control_deploy as deploy_app
 from calvin.utilities import calvinlogger
 from calvin.utilities import calvinconfig
+from calvin.utilities.nodecontrol import dispatch_node
 
 _log = calvinlogger.get_logger(__name__)
 _conf = calvinconfig.get()


### PR DESCRIPTION
Got this error when trying to start a storage runtime:
(test-calvin) calvin-base(master)$ csruntime --host localhost --port 5003 --controlport 5004 --keep-alive  -s
2016-02-12 16:28:43,518 INFO     58224-calvin.calvin.runtime.north.calvincontrol: Listening on: localhost:5004
Unhandled Error
Traceback (most recent call last):
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/calvin-0.4-py2.7.egg/calvin/runtime/north/scheduler.py", line 45, in run
    async.run_ioloop()
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/calvin-0.4-py2.7.egg/calvin/runtime/south/plugins/async/twistedimpl/async.py", line 38, in run_ioloop
    reactor.run()
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/twisted/internet/base.py", line 1194, in run
    self.mainLoop()
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/twisted/internet/base.py", line 1203, in mainLoop
    self.runUntilCurrent()
--- <exception caught here> ---
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/twisted/internet/base.py", line 825, in runUntilCurrent
    call.func(_call.args, *_call.kw)
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/calvin-0.4-py2.7.egg/calvin/utilities/storage_node.py", line 69, in start
    self.storage.start()
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/calvin-0.4-py2.7.egg/calvin/runtime/north/storage.py", line 107, in start
    self.storage.start(iface=iface, cb=CalvinCB(self.started_cb, org_cb=cb))
  File "/Users/philipstahl/.virtualenvs/test-calvin/lib/python2.7/site-packages/calvin-0.4-py2.7.egg/calvin/runtime/north/plugins/storage/proxy/**init**.py", line 43, in start
    self.node.network.join([self.master_uri], CalvinCB(self._start_link_cb, org_cb=cb))
exceptions.AttributeError: 'StorageNode' object has no attribute 'network'

This change fixes that. It's tested with running one storage runtime, and two other runtimes with a config file specifying storage_proxy to the storage runtime. After deploying an app to the first runtime, I tested with "cscontrol <second_runtime> actor info <id_of_actor_on_first_runtime>" which works as expected.
