### PR TITLE
remove test files when done

### DIFF
--- a/calvin/actorstore/systemactors/io/FileWriter.py
+++ b/calvin/actorstore/systemactors/io/FileWriter.py
@@ -43,6 +43,8 @@ def verify_file(actor):
         with open(fname, "r") as fp:
             f = fp.read()
         result = "\n".join(l for l in file_data) + "\n" == f
+        os.remove(fname)
+
     return result
 
 


### PR DESCRIPTION
The FileWrite actor filled calvin/actorstore/systemactors/io with *.testing files. This change removes those files when the test is done.