### PR TITLE
Add additional unit tests for actor, actormanager, actorport, calvincontrol, calvinlogger, calvinresponse, calvin callback, and endpoint

### DIFF
--- a/calvin/actor/actor.py
+++ b/calvin/actor/actor.py
@@ -621,7 +621,7 @@ class Actor(object):
         if not isinstance(actor_ids, (set, list, tuple)):
             actor_ids = [actor_ids]
         self._component_members -= set(actor_ids)
-        
+
     def part_of_component(self):
         return len(self._component_members - set([self.id]))>0
 
@@ -645,13 +645,14 @@ class Actor(object):
         if self._signature is None:
             self._signature = signature
 
+
 class ShadowActor(Actor):
     """A shadow actor try to behave as another actor but don't have any implementation"""
     def __init__(self, actor_type, name='', allow_invalid_transitions=True, disable_transition_checks=False,
                  disable_state_checks=False, actor_id=None):
         self.inport_names = []
         self.outport_names = []
-        super(ShadowActor, self).__init__(actor_type, name, allow_invalid_transitions=allow_invalid_transitions, 
+        super(ShadowActor, self).__init__(actor_type, name, allow_invalid_transitions=allow_invalid_transitions,
                                             disable_transition_checks=disable_transition_checks,
                                             disable_state_checks=disable_state_checks, actor_id=actor_id)
 

--- a/calvin/actor/actorport.py
+++ b/calvin/actor/actorport.py
@@ -89,7 +89,7 @@ class InPort(Port):
         return self.endpoint.is_connected()
 
     def is_connected_to(self, peer_id):
-        return self.endpoint.is_connected() and self.endpoint.get_peer()[1]==peer_id
+        return self.endpoint.is_connected() and self.endpoint.get_peer()[1] == peer_id
 
     def attach_endpoint(self, endpoint_):
         old_endpoint = self.endpoint
@@ -213,8 +213,7 @@ class OutPort(Port):
 
     def write_token(self, data):
         """docstring for write_token"""
-        ok = self.fifo.write(data)
-        if not ok:
+        if not self.fifo.write(data):
             raise Exception("FIFO full when writing to port %s.%s with id: %s" % (
                 self.owner.name, self.name, self.id))
 

--- a/calvin/csparser/analyzer.py
+++ b/calvin/csparser/analyzer.py
@@ -28,6 +28,7 @@ def full_port_name(namespace, actor_name, port_name):
         return namespace + ':' + actor_name + '.' + port_name
     return namespace + '.' + port_name
 
+
 class Analyzer(object):
 
     """
@@ -52,7 +53,6 @@ class Analyzer(object):
         self.actors = {}
         self.verify = verify
         self.analyze()
-
 
     def analyze(self):
         """
@@ -79,7 +79,7 @@ class Analyzer(object):
         except Exception as e:
             _log.exception(e)
             valid = False
-        self.app_info = {'valid':valid, 'actors': self.actors, 'connections':self.connections}
+        self.app_info = {'valid': valid, 'actors': self.actors, 'connections': self.connections}
         if self.script_name:
             self.app_info['name'] = self.script_name
 
@@ -97,7 +97,6 @@ class Analyzer(object):
         if kind != "IDENTIFIER":
             return (kind, value)
         return self.lookup_constant(value)
-
 
     def lookup(self, actor_type):
         """
@@ -137,10 +136,16 @@ class Analyzer(object):
                 else:
                     kind, value = self.lookup_constant(value)
             # Replace constant with std.Constant(data=value, n=-1) its outport
-            name = '_literal_const_'+str(const_count)
+            name = '_literal_const_' + str(const_count)
             const_count += 1
             # Replace implicit actor with actual actor ...
-            structure['actors'][name] = {'actor_type':'std.Constant', 'args':{'data':(kind, value), 'n':('NUMBER', -1)}, 'dbg_line':c['dbg_line']}
+            structure['actors'][name] = {
+                'actor_type': 'std.Constant',
+                'args': {
+                    'data': (kind, value),
+                    'n': ('NUMBER', -1)
+                },
+                'dbg_line': c['dbg_line']}
             # ... and create a connection from it
             c['src'] = name
             c['src_port'] = 'token'
@@ -178,13 +183,12 @@ class Analyzer(object):
             # Add mapping from component inport to internal actors/components
             if type(dst_actor_port) is not list:
                 dst_actor_port = [dst_actor_port]
-            export_mapping = {src_actor_port:dst_actor_port}, {}
+            export_mapping = {src_actor_port: dst_actor_port}, {}
         else:
             # Add mapping from internal actor/component to component outport
-            export_mapping = {}, {dst_actor_port:src_actor_port}
+            export_mapping = {}, {dst_actor_port: src_actor_port}
 
         return export_mapping
-
 
     def analyze_structure(self, structure, namespace, argd):
         """
@@ -200,18 +204,18 @@ class Analyzer(object):
         out_mappings = {}
         for actor_name, actor_def in structure['actors'].iteritems():
             # Look up actor
-            info, is_actor= self.lookup(actor_def['actor_type'])
+            info, is_actor = self.lookup(actor_def['actor_type'])
             # Resolve arguments
             args = self.resolve_arguments(actor_def['args'], argd)
 
-            qualified_name = namespace+':'+actor_name
+            qualified_name = namespace + ':' + actor_name
 
             if is_actor:
                 # Create the actor signature to be able to look it up in the GlobalStore if neccessary
-                signature_desc={'is_primitive': True,
-                                'actor_type':actor_def['actor_type'],
-                                'inports': [],
-                                'outports': []}
+                signature_desc = {'is_primitive': True,
+                                  'actor_type': actor_def['actor_type'],
+                                  'inports': [],
+                                  'outports': []}
                 for c in structure['connections']:
                     if actor_name == c['src'] and c['src_port'] not in signature_desc['outports']:
                         signature_desc['outports'].append(c['src_port'])
@@ -219,7 +223,7 @@ class Analyzer(object):
                         signature_desc['inports'].append(c['dst_port'])
                 signature = GlobalStore.actor_signature(signature_desc)
                 # Add actor and its arguments to the list of actor instances
-                self.actors[qualified_name] = {'actor_type':actor_def['actor_type'], 'args':args,
+                self.actors[qualified_name] = {'actor_type': actor_def['actor_type'], 'args': args,
                                                'signature': signature, 'signature_desc': signature_desc}
             else:
                 # Recurse into components
@@ -238,6 +242,7 @@ class Analyzer(object):
 
         return export_in_mappings, export_out_mappings
 
+
 def generate_app_info(cs_info, verify=True):
     a = Analyzer(cs_info, verify=verify)
     return a.app_info
@@ -254,11 +259,8 @@ if __name__ == '__main__':
         print "---------------"
         data, errors, warnings = cscompiler.compile(script, filename)
         if errors:
-            print "{reason} {script} [{line}:{col}]".format(script=filename, **error[0])
+            print "{reason} {script} [{line}:{col}]".format(script=filename, **errors[0])
 
         a = Analyzer(data)
         print "======= DONE ========"
         print json.dumps(a.app_info, indent=4, sort_keys=True)
-
-
-

--- a/calvin/csparser/parser.py
+++ b/calvin/csparser/parser.py
@@ -20,14 +20,17 @@ import ply.yacc as yacc
 import calvin_rules
 from calvin_rules import tokens
 
+
 class CalvinSyntaxError(Exception):
     def __init__(self, message, token):
         super(CalvinSyntaxError, self).__init__(message)
         self.token = token
 
+
 class CalvinEOFError(Exception):
     def __init__(self, message):
         super(CalvinEOFError, self).__init__(message)
+
 
 def p_script(p):
     """script : constdefs compdefs opt_program"""
@@ -45,7 +48,7 @@ def p_constdefs(p):
 
 def p_constdef(p):
     """constdef : DEFINE IDENTIFIER EQ argument"""
-    constdef = {p[2]:p[4]}
+    constdef = {p[2]: p[4]}
     p[0] = constdef
 
 
@@ -59,7 +62,9 @@ def p_compdefs(p):
 
 
 def p_compdef(p):
-    """compdef : COMPONENT qualified_name LPAREN identifiers RPAREN identifiers RARROW identifiers LBRACE docstring program RBRACE"""
+    """compdef : COMPONENT qualified_name LPAREN identifiers RPAREN identifiers RARROW identifiers LBRACE docstring
+    program RBRACE
+    """
     name = p[2]
     arg_ids = p[4]
     inputs = p[6]
@@ -73,9 +78,9 @@ def p_compdef(p):
         'arg_identifiers': arg_ids,
         'structure': structure,
         'docstring': docstring,
-        'dbg_line':p.lineno(2)
+        'dbg_line': p.lineno(2)
     }
-    p[0] = {name:comp}
+    p[0] = {name: comp}
 
 
 def p_docstring(p):
@@ -125,7 +130,7 @@ def p_statement(p):
 
 def p_assignment(p):
     """assignment : IDENTIFIER COLON qualified_name LPAREN named_args RPAREN"""
-    p[0] = ('assignment', {p[1]: {'actor_type': p[3], 'args': p[5], 'dbg_line':p.lineno(2)}})
+    p[0] = ('assignment', {p[1]: {'actor_type': p[3], 'args': p[5], 'dbg_line': p.lineno(2)}})
 
 
 def p_link(p):
@@ -181,51 +186,51 @@ def p_value(p):
 
 
 def p_bool(p):
-  """bool : TRUE
-          | FALSE"""
-  p[0] = bool(p.slice[1].type == 'TRUE')
+    """bool : TRUE
+            | FALSE"""
+    p[0] = bool(p.slice[1].type == 'TRUE')
 
 
 def p_null(p):
-  """null : NULL"""
-  p[0] = None
+    """null : NULL"""
+    p[0] = None
 
 
 def p_dictionary(p):
-  """dictionary : LBRACE members RBRACE"""
-  p[0] = dict(p[2])
+    """dictionary : LBRACE members RBRACE"""
+    p[0] = dict(p[2])
 
 
 def p_members(p):
-  """members :
-             | members member COMMA
-             | members member"""
-  if len(p) == 1:
-    p[0] = list()
-  else:
-    p[1].append(p[2])
-    p[0] = p[1]
+    """members :
+                | members member COMMA
+                | members member"""
+    if len(p) == 1:
+        p[0] = list()
+    else:
+        p[1].append(p[2])
+        p[0] = p[1]
 
 
 def p_member(p):
-  """member : STRING COLON value"""
-  p[0] = (p[1], p[3])
+    """member : STRING COLON value"""
+    p[0] = (p[1], p[3])
 
 
 def p_values(p):
-  """values :
-            | values value COMMA
-            | values value"""
-  if len(p) == 1:
-    p[0] = list()
-  else:
-    p[1].append(p[2])
-    p[0] = p[1]
+    """values :
+                | values value COMMA
+                | values value"""
+    if len(p) == 1:
+        p[0] = list()
+    else:
+        p[1].append(p[2])
+        p[0] = p[1]
 
 
 def p_array(p):
-  """array :  LBRACK values RBRACK"""
-  p[0] = p[2]
+    """array :  LBRACK values RBRACK"""
+    p[0] = p[2]
 
 
 # def p_opt_id_list(p):
@@ -275,15 +280,17 @@ def _calvin_parser():
     parser = yacc.yacc(debug=False, optimize=True, outputdir=containing_dir)
     return parser
 
+
 # Compute column.
 #     input is the input text string
 #     token is a token instance
 def _find_column(input, token):
     last_cr = input.rfind('\n', 0, token.lexpos)
     if last_cr < 0:
-	    last_cr = 0
+        last_cr = 0
     column = (token.lexpos - last_cr) + 1
     return column
+
 
 def calvin_parser(source_text, source_file=''):
     parser = _calvin_parser()
@@ -295,17 +302,17 @@ def calvin_parser(source_text, source_file=''):
         result = parser.parse(source_text)
     except CalvinSyntaxError as e:
         error = {
-            'reason':str(e),
-            'line':e.token.lexer.lineno,
-            'col':_find_column(source_text, e.token)
+            'reason': str(e),
+            'line': e.token.lexer.lineno,
+            'col': _find_column(source_text, e.token)
         }
         errors.append(error)
     except CalvinEOFError as e:
         lines = source_text.splitlines()
         error = {
-            'reason':str(e),
-            'line':len(lines),
-            'col':len(lines[-1])
+            'reason': str(e),
+            'line': len(lines),
+            'col': len(lines[-1])
         }
         errors.append(error)
 
@@ -318,7 +325,6 @@ def calvin_parser(source_text, source_file=''):
 
 if __name__ == '__main__':
     import sys
-    import os
     import json
 
     if len(sys.argv) < 2:

--- a/calvin/runtime/north/calvincontrol.py
+++ b/calvin/runtime/north/calvincontrol.py
@@ -250,7 +250,7 @@ control_api_doc += \
         "extend": True or False  # defaults to False, i.e. replace current requirements
         "move": True or False  # defaults to False, i.e. when possible stay on the current node
     }
-    
+
     For further details about requirements see application deploy.
     Response status code: OK, BAD_REQUEST, INTERNAL_ERROR or NOT_FOUND
     Response: none
@@ -345,14 +345,14 @@ control_api_doc += \
            }
     }
     Note that either a script or app_info must be supplied.
-    
+
     The matching rules are implemented as plug-ins, intended to be extended.
     The type "+" is "and"-ing rules together (actually the intersection of all
     possible nodes returned by the rules.) The type "-" is explicitly removing
     the nodes returned by this rule from the set of possible nodes. Note that
     only negative rules will result in no possible nodes, i.e. there is no
     implied "all but these."
-    
+
     A special matching rule exist, to first form a union between matching
     rules, i.e. alternative matches. This is useful for e.g. alternative
     namings, ownerships or specifying either of two specific nodes.
@@ -461,7 +461,7 @@ control_api_doc += \
     Response status code: OK or NOT_FOUND
     Response:
     {
-        <actor-id>: 
+        <actor-id>:
             [
                 [<seconds since epoch>, <name of action>],
                 ...
@@ -480,7 +480,7 @@ control_api_doc += \
     {
         'activity':
         {
-            <actor-id>: 
+            <actor-id>:
             {
                 <action-name>: <total fire count>,
                 ...
@@ -503,7 +503,7 @@ control_api_doc += \
     Response status code: OK or NOT_FOUND
     Response:
     {
-        <actor-id>: 
+        <actor-id>:
         {
             <action-name>:
             {
@@ -777,8 +777,7 @@ class CalvinControl(object):
         if connection is not None:
             if not connection.connection_lost:
                 connection.send(response)
-        else:
-            if self.tunnel_client is not None:
+        elif self.tunnel_client is not None:
                 msg = {"cmd": "logresp", "msgid": handle, "header": response, "data": None}
                 self.tunnel_client.send(msg)
 
@@ -1168,7 +1167,7 @@ class CalvinControl(object):
         except:
             _log.exception("handle_get_timed_meter")
             status = calvinresponse.NOT_FOUND
-        self.send_response(handle, connection, 
+        self.send_response(handle, connection,
             json.dumps(data) if status == calvinresponse.OK else None, status=status)
 
     def handle_get_aggregated_meter(self, handle, connection, match, data, hdr):
@@ -1178,7 +1177,7 @@ class CalvinControl(object):
         except:
             _log.exception("handle_get_aggregated_meter")
             status = calvinresponse.NOT_FOUND
-        self.send_response(handle, connection, 
+        self.send_response(handle, connection,
             json.dumps(data) if status == calvinresponse.OK else None, status=status)
 
     def handle_get_metainfo_meter(self, handle, connection, match, data, hdr):
@@ -1188,7 +1187,7 @@ class CalvinControl(object):
         except:
             _log.exception("handle_get_metainfo_meter")
             status = calvinresponse.NOT_FOUND
-        self.send_response(handle, connection, 
+        self.send_response(handle, connection,
             json.dumps(data) if status == calvinresponse.OK else None, status=status)
 
     def handle_post_index(self, handle, connection, match, data, hdr):

--- a/calvin/runtime/north/tests/test_storage.py
+++ b/calvin/runtime/north/tests/test_storage.py
@@ -19,6 +19,7 @@ from calvin.runtime.north import storage
 from calvin.runtime.north import appmanager
 from calvin.runtime.south.plugins.async import threads
 from calvin.utilities.calvin_callback import CalvinCB
+from calvin.tests import TestNode, TestActor, TestPort
 import Queue
 import pytest
 import time
@@ -27,42 +28,6 @@ try:
     import pytest.inlineCallbacks
 except ImportError:
     pytest.inlineCallbacks = lambda *args: False
-
-
-class TestNode:
-
-    def __init__(self, uri):
-        self.id = calvinuuid.uuid("NODE")
-        self.uri = uri
-
-
-class TestActor:
-
-    def __init__(self, name, type, inports, outports):
-        self.id = calvinuuid.uuid("ACTOR")
-        self.name = name
-        self._type = type
-        self.inports = inports
-        self.outports = outports
-
-
-class TestPort:
-
-    def __init__(self, name, direction):
-        self.id = calvinuuid.uuid("PORT")
-        self.name = name
-        self.direction = direction
-        self.peer = None
-        self.peers = None
-
-    def is_connected(self):
-        return True
-
-    def get_peer(self):
-        return self.peer
-
-    def get_peers(self):
-        return self.peers
 
 
 @pytest.mark.interactive

--- a/calvin/runtime/south/endpoint.py
+++ b/calvin/runtime/south/endpoint.py
@@ -327,17 +327,16 @@ class TunnelOutEndpoint(Endpoint):
             while self.port.fifo.can_read(self.peer_id):
                 sent = True
                 self._send_one_token()
-        else:
+        elif (self.port.fifo.can_read(self.peer_id) and
+              self.port.fifo.tentative_read_pos[self.peer_id] == self.port.fifo.read_pos[self.peer_id] and
+              time.time() >= self.time_cont):
             # Send only one since other side sent NACK likely due to their FIFO is full
-            if (self.port.fifo.can_read(self.peer_id) and
-               self.port.fifo.tentative_read_pos[self.peer_id] == self.port.fifo.read_pos[self.peer_id] and
-               time.time() >= self.time_cont):
-                # Something to read and last (N)ACK recived
-                self._send_one_token()
-                sent = True
-                self.time_cont = time.time() + self.backoff
-                # Make sure that resend will be tried in backoff seconds
-                self.trigger_loop(self.backoff)
+            # Something to read and last (N)ACK recived
+            self._send_one_token()
+            sent = True
+            self.time_cont = time.time() + self.backoff
+            # Make sure that resend will be tried in backoff seconds
+            self.trigger_loop(self.backoff)
         return sent
 
     def get_peer(self):

--- a/calvin/tests/__init__.py
+++ b/calvin/tests/__init__.py
@@ -1,0 +1,17 @@
+
+from mock import Mock
+
+from calvin.runtime.north import metering
+
+
+class DummyNode:
+
+    def __init__(self):
+        self.id = id(self)
+        self.pm = Mock()
+        self.storage = Mock()
+        self.control = Mock()
+        self.metering = metering.set_metering(metering.Metering(self))
+
+    def calvinsys(self):
+        return None

--- a/calvin/tests/__init__.py
+++ b/calvin/tests/__init__.py
@@ -2,6 +2,8 @@
 from mock import Mock
 
 from calvin.runtime.north import metering
+from calvin.utilities import calvinuuid
+from calvin.runtime.north.fifo import FIFO
 
 
 class DummyNode:
@@ -15,3 +17,40 @@ class DummyNode:
 
     def calvinsys(self):
         return None
+
+
+class TestNode:
+
+    def __init__(self, uri):
+        self.id = calvinuuid.uuid("NODE")
+        self.uri = uri
+
+
+class TestActor:
+
+    def __init__(self, name, type, inports, outports):
+        self.id = calvinuuid.uuid("ACTOR")
+        self.name = name
+        self._type = type
+        self.inports = inports
+        self.outports = outports
+
+
+class TestPort:
+
+    def __init__(self, name, direction):
+        self.id = calvinuuid.uuid("PORT")
+        self.name = name
+        self.direction = direction
+        self.peer = None
+        self.peers = None
+        self.fifo = FIFO(5)
+
+    def is_connected(self):
+        return True
+
+    def get_peer(self):
+        return self.peer
+
+    def get_peers(self):
+        return self.peers

--- a/calvin/tests/test_actor.py
+++ b/calvin/tests/test_actor.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import pytest
-from mock import Mock, patch
+
+from mock import Mock
+from calvin.tests import DummyNode
 from calvin.runtime.north.actormanager import ActorManager
-from calvin.runtime.north import metering
 from calvin.runtime.south.endpoint import LocalOutEndpoint, LocalInEndpoint
 from calvin.actor.actor import Actor
 
@@ -34,19 +34,6 @@ def create_actor(node):
 @pytest.fixture
 def actor():
     return create_actor(DummyNode())
-
-
-class DummyNode:
-
-    def __init__(self):
-        self.id = id(self)
-        self.pm = Mock()
-        self.storage = Mock()
-        self.control = Mock()
-        self.metering = metering.set_metering(metering.Metering(self))
-
-    def calvinsys(self):
-        return None
 
 
 @pytest.mark.parametrize("port_type,port_name,port_property,value,expected", [

--- a/calvin/tests/test_actor.py
+++ b/calvin/tests/test_actor.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015 Ericsson AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pytest
+from mock import Mock, patch
+from calvin.runtime.north.actormanager import ActorManager
+from calvin.runtime.north import metering
+from calvin.runtime.south.endpoint import LocalOutEndpoint, LocalInEndpoint
+from calvin.actor.actor import Actor
+
+
+def create_actor(node):
+    actor_manager = ActorManager(node)
+    actor_id = actor_manager.new('std.Identity', {})
+    actor = actor_manager.actors[actor_id]
+    actor._calvinsys = Mock()
+    return actor
+
+
+@pytest.fixture
+def actor():
+    return create_actor(DummyNode())
+
+
+class DummyNode:
+
+    def __init__(self):
+        self.id = id(self)
+        self.pm = Mock()
+        self.storage = Mock()
+        self.control = Mock()
+        self.metering = metering.set_metering(metering.Metering(self))
+
+    def calvinsys(self):
+        return None
+
+
+@pytest.mark.parametrize("port_type,port_name,port_property,value,expected", [
+    ("invalid", "", "", "", False),
+    ("in", "missing", "", "", False),
+    ("out", "missing", "", "", False),
+    ("out", "token", "missing", "", False),
+    ("in", "token", "missing", "", False),
+    ("out", "token", "name", "new_name", True),
+    ("out", "token", "name", "new_name", True),
+])
+def test_set_port_property(port_type, port_name, port_property, value, expected):
+    assert actor().set_port_property(port_type, port_name, port_property, value) is expected
+
+
+@pytest.mark.parametrize("inport_ret_val,outport_ret_val,expected", [
+    (False, False, False),
+    (False, True, False),
+    (True, False, False),
+    (True, True, True),
+])
+def test_did_connect(actor, inport_ret_val, outport_ret_val, expected):
+    for port in actor.inports.values():
+        port.is_connected = Mock(return_value=inport_ret_val)
+    for port in actor.outports.values():
+        port.is_connected = Mock(return_value=outport_ret_val)
+
+    actor.fsm = Mock()
+    actor.did_connect(None)
+    if expected:
+        actor.fsm.transition_to.assert_called_with(Actor.STATUS.ENABLED)
+        assert actor._calvinsys.scheduler_wakeup.called
+    else:
+        assert not actor.fsm.transition_to.called
+        assert not actor._calvinsys.scheduler_wakeup.called
+
+
+@pytest.mark.parametrize("inport_ret_val,outport_ret_val,expected", [
+    (True, True, False),
+    (True, False, False),
+    (False, True, False),
+    (False, False, True),
+])
+def test_did_disconnect(actor, inport_ret_val, outport_ret_val, expected):
+    for port in actor.inports.values():
+        port.is_connected = Mock(return_value=inport_ret_val)
+    for port in actor.outports.values():
+        port.is_connected = Mock(return_value=outport_ret_val)
+
+    actor.fsm = Mock()
+    actor.did_disconnect(None)
+    if expected:
+        actor.fsm.transition_to.assert_called_with(Actor.STATUS.READY)
+    else:
+        assert not actor.fsm.transition_to.called
+
+
+def test_enabled(actor):
+    actor.enable()
+    assert actor.enabled()
+    actor.disable()
+    assert not actor.enabled()
+
+
+def test_connections():
+    node = DummyNode()
+    node.id = "node_id"
+    actor = create_actor(node)
+    inport = actor.inports['token']
+    outport = actor.outports['token']
+
+    port = Mock()
+    port.id = "x"
+    peer_port = Mock()
+    peer_port.id = "y"
+
+    inport.attach_endpoint(LocalInEndpoint(port, peer_port))
+    outport.attach_endpoint(LocalOutEndpoint(port, peer_port))
+
+    assert actor.connections(node) == {
+        'actor_id': actor.id,
+        'actor_name': actor.name,
+        'inports': {inport.id: (node, "y")},
+        'outports': {outport.id: [(node, "y")]}
+    }
+
+
+def test_state(actor):
+    inport = actor.inports['token']
+    outport = actor.outports['token']
+    assert actor.state() == {
+        '_component_members': [actor.id],
+        '_deployment_requirements': [],
+        '_managed': ['dump', '_signature', 'id', '_deployment_requirements', 'name'],
+        '_signature': None,
+        'dump': False,
+        'id': actor.id,
+        'inports': {'token': {'fifo': {'N': 5,
+                                       'fifo': [{'data': 0, 'type': 'Token'},
+                                                {'data': 0, 'type': 'Token'},
+                                                {'data': 0, 'type': 'Token'},
+                                                {'data': 0, 'type': 'Token'},
+                                                {'data': 0, 'type': 'Token'}],
+                                       'read_pos': {inport.id: 0},
+                                       'readers': [inport.id],
+                                       'tentative_read_pos': {inport.id: 0},
+                                       'write_pos': 0},
+                              'id': inport.id,
+                              'name': 'token'}},
+        'name': '',
+        'outports': {'token': {'fanout': 1,
+                               'fifo': {'N': 5,
+                                        'fifo': [{'data': 0, 'type': 'Token'},
+                                                 {'data': 0, 'type': 'Token'},
+                                                 {'data': 0, 'type': 'Token'},
+                                                 {'data': 0, 'type': 'Token'},
+                                                 {'data': 0, 'type': 'Token'}],
+                                        'read_pos': {},
+                                        'readers': [],
+                                        'tentative_read_pos': {},
+                                        'write_pos': 0},
+                               'id': outport.id,
+                               'name': 'token'}}}
+
+
+@pytest.mark.parametrize("prev_signature,new_signature,expected", [
+    (None, "new_val", "new_val"),
+    ("old_val", "new_val", "old_val")
+])
+def test_set_signature(actor, prev_signature, new_signature, expected):
+    actor.signature_set(prev_signature)
+    actor.signature_set(new_signature)
+    assert actor._signature == expected
+
+
+def test_component(actor):
+    actor.component_add(1)
+    assert 1 in actor.component_members()
+
+    actor.component_add([2, 3])
+    assert 2 in actor.component_members()
+    assert 3 in actor.component_members()
+
+    actor.component_remove(1)
+    assert 1 not in actor.component_members()
+    actor.component_remove([2, 3])
+    assert 2 not in actor.component_members()
+    assert 3 not in actor.component_members()
+
+
+def test_requirements(actor):
+    assert actor.requirements_get() == []
+    actor.requirements_add([1, 2, 3])
+    assert actor.requirements_get() == [1, 2, 3]
+    actor.requirements_add([4, 5])
+    assert actor.requirements_get() == [4, 5]
+    actor.requirements_add([6, 7], extend=True)
+    assert actor.requirements_get() == [4, 5, 6, 7]

--- a/calvin/tests/test_actormanager.py
+++ b/calvin/tests/test_actormanager.py
@@ -15,18 +15,20 @@
 # limitations under the License.
 
 import unittest
-import mock
+import pytest
+from mock import Mock, patch
 from calvin.runtime.north.actormanager import ActorManager
 from calvin.runtime.north import metering
+from calvin.utilities.calvin_callback import CalvinCB
 
 
 class DummyNode:
 
     def __init__(self):
         self.id = id(self)
-        self.pm = mock.Mock()
-        self.storage = mock.Mock()
-        self.control = mock.Mock()
+        self.pm = Mock()
+        self.storage = Mock()
+        self.control = Mock()
         self.metering = metering.set_metering(metering.Metering(self))
 
     def calvinsys(self):
@@ -49,14 +51,14 @@ class ActorManagerTests(unittest.TestCase):
         self.assertTrue(a)
         return a, a_id
 
-    def testNewActor(self):
+    def test_new_actor(self):
         # Test basic actor creation
         a_type = 'std.Constant'
         data = 42
         a, _ = self._new_actor(a_type, {'data':data})
         self.assertEqual(a.data, data)
 
-    def testActorStateGet(self):
+    def test_actor_state_get(self):
         # Test basic actor state retrieval
         a_type = 'std.Constant'
         data = 42
@@ -67,8 +69,7 @@ class ActorManagerTests(unittest.TestCase):
         self.assertEqual(s['id'], a_id)
         self.assertEqual(s['n'], 1)
 
-
-    def testNewActorFromState(self):
+    def test_new_actor_from_state(self):
         # Test basic actor state manipulation
         a_type = 'std.Constant'
         data = 42
@@ -89,6 +90,134 @@ class ActorManagerTests(unittest.TestCase):
         self.assertTrue(self.am.actors[a_id])
         self.assertEqual(len(self.am.actors), 1)
 
+    @patch('calvin.runtime.north.storage.Storage.delete_actor')
+    @patch('calvin.runtime.north.metering.Metering.remove_actor_info')
+    def test_destroy_actor(self, remove_actor_info, delete_actor):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+
+        self.am.destroy(actor_id)
+
+        assert actor_id not in self.am.actors
+        remove_actor_info.assert_called_with(actor_id)
+        self.am.node.storage.delete_actor.assert_called_with(actor_id)
+        self.am.node.control.log_actor_destroy.assert_called_with(actor_id)
+
+    def test_enable_actor(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+
+        actor.enable = Mock()
+        self.am.enable(actor_id)
+        assert actor.enable.called
+
+    def test_disable_actor(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+
+        actor.disable = Mock()
+        self.am.disable(actor_id)
+        assert actor.disable.called
+
+    def test_migrate_to_same_node_does_nothing(self):
+        callback_mock = Mock()
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+        actor.will_migrate = Mock()
+
+        self.am.migrate(actor_id, self.am.node.id, callback_mock)
+        assert not actor.will_migrate.called
+        assert callback_mock.called
+        args, kwargs = callback_mock.call_args
+        self.assertEqual(kwargs['status'].status, 200)
+
+    def test_migrate_non_existing_actor_returns_false(self):
+        callback_mock = Mock()
+
+        self.am.migrate("123", self.am.node.id, callback_mock)
+        assert callback_mock.called
+        args, kwargs = callback_mock.call_args
+        self.assertEqual(kwargs['status'].status, 500)
+
+    def test_migrate(self):
+        callback_mock = Mock()
+
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+        peer_node = DummyNode()
+
+        actor.will_migrate = Mock()
+
+        self.am.migrate(actor_id, peer_node.id, callback_mock)
+
+        assert actor.will_migrate.called
+        assert self.am.node.pm.disconnect.called
+
+        args, kwargs = self.am.node.pm.disconnect.call_args
+        self.assertEqual(kwargs['actor_id'], actor_id)
+
+        cb = kwargs['callback']
+        self.assertEqual(cb.kwargs['actor'], actor)
+        self.assertEqual(cb.kwargs['actor_type'], actor._type)
+        self.assertEqual(cb.kwargs['callback'], callback_mock)
+        self.assertEqual(cb.kwargs['node_id'], peer_node.id)
+        self.assertEqual(cb.kwargs['ports'], actor.connections(self.am.node.id))
+        self.am.node.control.log_actor_migrate.assert_called_once_with(actor_id, peer_node.id)
+
+    def test_connect(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42})
+        connection_list = [['1', '2', '3', '4'], ['5', '6', '7', '8']]
+        callback_mock = Mock()
+
+        self.am.connect(actor_id, connection_list, callback_mock)
+
+        self.assertEqual(self.am.node.pm.connect.call_count, 2)
+        calls = self.am.node.pm.connect.call_args_list
+        for index, (args, kwargs) in enumerate(calls):
+            self.assertEqual(kwargs['port_id'], connection_list[index][1])
+            self.assertEqual(kwargs['peer_node_id'], connection_list[index][2])
+            self.assertEqual(kwargs['peer_port_id'], connection_list[index][3])
+            callback = kwargs['callback'].kwargs
+            self.assertEqual(callback['peer_port_id'], connection_list[index][3])
+            self.assertEqual(callback['actor_id'], actor_id)
+            self.assertEqual(callback['peer_port_ids'], ['4', '8'])
+            self.assertEqual(callback['_callback'], callback_mock)
+
+    def test_connections_returns_actor_connections_for_current_node(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        expected = {
+            'actor_name': 'actor',
+            'actor_id': actor_id,
+            'inports': {},
+            'outports': {actor.outports['token'].id: actor.outports['token'].get_peers()}
+        }
+        self.assertEqual(self.am.connections(actor_id), expected)
+
+    def test_missing_actor(self):
+        test_functions = [("report", ()), ("destroy", ()), ("enable", ()), ("disable", ()),
+                          ("connect", ([], None)), ("connections", ()), ("dump", ()),
+                          ("set_port_property", (None, None, None, None)),
+                          ("get_port_state", (None, ))]
+        for func, args in test_functions:
+            with pytest.raises(Exception) as excinfo:
+                print func
+                getattr(self.am, func)('123', *args)
+            assert "Actor '123' not found" in str(excinfo.value)
+
+    def test_actor_type(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        self.assertEqual(self.am.actor_type(actor_id), 'std.Constant')
+
+    def test_actor_type_of_missing_actor(self):
+        self.assertEqual(self.am.actor_type("123"), 'BAD ACTOR')
+
+    def test_enabled_actors(self):
+        actor, actor_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        enabled_actor, enabled_actor_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        enabled_actor.enable()
+        self.assertEqual(self.am.enabled_actors(), [enabled_actor])
+
+    def test_list_actors(self):
+        actor_1, actor_1_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        actor_2, actor_2_id = self._new_actor('std.Constant', {'data': 42, 'name': 'actor'})
+        actors = self.am.list_actors()
+        assert actor_1_id in actors
+        assert actor_2_id in actors
 
 
 if __name__ == '__main__':

--- a/calvin/tests/test_actormanager.py
+++ b/calvin/tests/test_actormanager.py
@@ -17,22 +17,9 @@
 import unittest
 import pytest
 from mock import Mock, patch
+
+from calvin.tests import DummyNode
 from calvin.runtime.north.actormanager import ActorManager
-from calvin.runtime.north import metering
-from calvin.utilities.calvin_callback import CalvinCB
-
-
-class DummyNode:
-
-    def __init__(self):
-        self.id = id(self)
-        self.pm = Mock()
-        self.storage = Mock()
-        self.control = Mock()
-        self.metering = metering.set_metering(metering.Metering(self))
-
-    def calvinsys(self):
-        return None
 
 
 class ActorManagerTests(unittest.TestCase):

--- a/calvin/tests/test_actorport.py
+++ b/calvin/tests/test_actorport.py
@@ -103,8 +103,7 @@ def test_disconnect_outport(inport, outport):
     outport.attach_endpoint(endpoint_2)
     assert outport.disconnect() == [endpoint_1, endpoint_2]
     assert outport.owner.did_disconnect.called
-    outport.fifo.commit_reads.assert_has_calls(call(endpoint_1.peer_id, False))
-    outport.fifo.commit_reads.assert_has_calls(call(endpoint_2.peer_id, False))
+    outport.fifo.commit_reads.assert_has_calls([call(endpoint_1.peer_id, False), call(endpoint_2.peer_id, False)])
 
 
 def test_inport_outport_connection(inport, outport):

--- a/calvin/tests/test_actorport.py
+++ b/calvin/tests/test_actorport.py
@@ -1,0 +1,181 @@
+import pytest
+
+from mock import Mock, call
+
+from calvin.runtime.north.actormanager import ActorManager
+from calvin.tests import DummyNode
+from calvin.runtime.south.endpoint import LocalOutEndpoint, LocalInEndpoint
+from calvin.actor.actor import Actor
+from calvin.actor.actorport import InPort, OutPort
+
+
+def create_actor(node):
+    actor_manager = ActorManager(node)
+    actor_id = actor_manager.new('std.Identity', {})
+    actor = actor_manager.actors[actor_id]
+    actor._calvinsys = Mock()
+    return actor
+
+
+@pytest.fixture
+def actor():
+    return create_actor(DummyNode())
+
+
+@pytest.fixture
+def inport():
+    return InPort("inport", actor())
+
+
+@pytest.fixture
+def outport():
+    return OutPort("outport", actor())
+
+
+def test_attach_endpoint_to_inport(inport, outport):
+    inport.owner.did_connect = Mock()
+    old_inport = InPort("in", actor())
+    old_endpoint = LocalInEndpoint(OutPort("out", actor()), old_inport)
+    endpoint = LocalInEndpoint(outport, inport)
+
+    inport.attach_endpoint(old_endpoint)
+    assert inport.is_connected_to(old_inport.id)
+
+    prev_endpoint = inport.attach_endpoint(endpoint)
+    assert prev_endpoint == old_endpoint
+    assert inport.is_connected_to(inport.id)
+    assert not inport.is_connected_to(old_inport.id)
+    assert inport.owner.did_connect.called
+
+
+def test_detach_endpoint_from_inport(inport, outport):
+    inport.owner.did_disconnect = Mock()
+    endpoint = LocalInEndpoint(outport, inport)
+
+    inport.attach_endpoint(endpoint)
+    assert inport.is_connected_to(inport.id)
+    inport.detach_endpoint(endpoint)
+    assert not inport.is_connected_to(inport.id)
+    assert inport.owner.did_disconnect.called
+
+
+def test_attach_endpoint_to_outport(inport, outport):
+    outport.owner.did_connect = Mock()
+    old_endpoint = LocalOutEndpoint(OutPort("out", actor()), InPort("out", actor()))
+    endpoint = LocalOutEndpoint(outport, inport)
+
+    outport.attach_endpoint(old_endpoint)
+    assert outport.is_connected_to(old_endpoint.peer_id)
+
+    outport.attach_endpoint(endpoint)
+    assert outport.is_connected_to(endpoint.peer_id)
+    assert outport.is_connected_to(old_endpoint.peer_id)
+    assert outport.owner.did_connect.called
+
+
+def test_detach_endpoint_from_outport(inport, outport):
+    outport.owner.did_disconnect = Mock()
+    endpoint = LocalOutEndpoint(outport, inport)
+
+    outport.attach_endpoint(endpoint)
+    assert outport.is_connected_to(endpoint.peer_id)
+    outport.detach_endpoint(endpoint)
+    assert not outport.is_connected_to(endpoint.peer_id)
+    assert outport.owner.did_disconnect.called
+
+
+def test_disconnect_inport(inport, outport):
+    inport.owner.did_disconnect = Mock()
+    endpoint = LocalInEndpoint(outport, inport)
+
+    inport.attach_endpoint(endpoint)
+    assert inport.disconnect() == [endpoint]
+    assert inport.owner.did_disconnect.called
+
+
+def test_disconnect_outport(inport, outport):
+    outport.owner.did_disconnect = Mock()
+    outport.fifo.commit_reads = Mock()
+    endpoint_1 = LocalOutEndpoint(outport, inport)
+    endpoint_2 = LocalOutEndpoint(outport, outport)
+
+    outport.attach_endpoint(endpoint_1)
+    outport.attach_endpoint(endpoint_2)
+    assert outport.disconnect() == [endpoint_1, endpoint_2]
+    assert outport.owner.did_disconnect.called
+    outport.fifo.commit_reads.assert_has_calls(call(endpoint_1.peer_id, False))
+    outport.fifo.commit_reads.assert_has_calls(call(endpoint_2.peer_id, False))
+
+
+def test_inport_outport_connection(inport, outport):
+    out_endpoint = LocalOutEndpoint(outport, inport)
+    in_endpoint = LocalInEndpoint(inport, outport)
+    outport.attach_endpoint(out_endpoint)
+    inport.attach_endpoint(in_endpoint)
+
+    assert outport.can_write()
+    assert outport.available_tokens() == 4
+
+    outport.write_token(1)
+    assert outport.available_tokens() == 3
+
+    assert inport.available_tokens() == 1
+    assert inport.peek_token() == 1
+    inport.peek_rewind()
+
+    assert inport.read_token() == 1
+    assert inport.available_tokens() == 0
+
+
+def test_set_outport_state(outport):
+    new_state = {
+        'fanout': 2,
+        'name': 'new_name',
+        'id': '123',
+        'fifo': {
+            'fifo': [{'value': 1} for n in range(5)],
+            'N': 5,
+            'readers': ['123'],
+            'write_pos': 3,
+            'read_pos': {'123': 2},
+            'tentative_read_pos': {'123': 0}
+        }
+    }
+    outport._set_state(new_state)
+
+    assert outport.name == 'new_name'
+    assert outport.id == '123'
+    assert outport.fanout == 2
+
+    assert outport.can_write()
+    assert outport.available_tokens() == 3
+    outport.write_token(10)
+    assert outport.fifo.fifo[3] == 10
+
+
+def test_set_inport_state(inport, outport):
+    out_endpoint = LocalOutEndpoint(outport, inport)
+    in_endpoint = LocalInEndpoint(inport, outport)
+    outport.attach_endpoint(out_endpoint)
+    inport.attach_endpoint(in_endpoint)
+
+    new_state = {
+        'name': 'new_name',
+        'id': inport.id,
+        'fifo': {
+            'fifo': [{'data': n} for n in range(5)],
+            'N': 5,
+            'readers': [in_endpoint.port.id],
+            'write_pos': 5,
+            'read_pos': {in_endpoint.port.id: 4},
+            'tentative_read_pos': {in_endpoint.port.id: 2}
+        }
+    }
+    inport._set_state(new_state)
+
+    assert inport.name == 'new_name'
+    assert inport.available_tokens() == 3
+    assert inport.read_token().value == 2
+    assert inport.read_token().value == 3
+    assert inport.read_token().value == 4
+    assert inport.read_token() is None

--- a/calvin/tests/test_calvin_callback.py
+++ b/calvin/tests/test_calvin_callback.py
@@ -1,0 +1,72 @@
+from mock import Mock
+
+from calvin.utilities.calvin_callback import CalvinCB, CalvinCBGroup, CalvinCBClass
+
+
+def test_call_callback():
+    func = Mock()
+    cb = CalvinCB(func=func)
+    cb()
+    assert func.called
+
+
+def test_call_callback_with_args():
+    func = Mock()
+    cb = CalvinCB(func, 1, 2, 3)
+    cb()
+    func.assert_called_with(1, 2, 3)
+
+
+def test_call_callback_with_kwargs():
+    func = Mock()
+    cb = CalvinCB(func, a=1, b=2, c=3)
+    cb()
+    func.assert_called_with(a=1, b=2, c=3)
+
+
+def test_args_update():
+    func = Mock()
+    cb = CalvinCB(func, 1, 2)
+    cb.args_append(3)
+    cb()
+    func.assert_called_with(1, 2, 3)
+
+
+def test_kwargs_update():
+    func = Mock()
+    cb = CalvinCB(func, 1, b=2)
+    cb.kwargs_update(c=3)
+    cb()
+    func.assert_called_with(1, b=2, c=3)
+
+
+def test_calvin_cb_group():
+    func1 = Mock()
+    func2 = Mock()
+    cb1 = CalvinCB(func1)
+    cb2 = CalvinCB(func2)
+    cbs = CalvinCBGroup([cb1, cb2])
+    cbs(1, 2, a=3)
+
+    func1.assert_called_with(1, 2, a=3)
+    func2.assert_called_with(1, 2, a=3)
+
+
+def test_calvin_cb_class():
+    func = Mock()
+    cb = CalvinCB(func)
+
+    func2 = Mock()
+    cb2 = CalvinCB(func2)
+
+    cb = CalvinCBClass(callbacks={'f': [cb]})
+    assert 'f' in cb.callback_valid_names()
+
+    cb.callback_register('f2', cb2)
+    assert 'f2' in cb.callback_valid_names()
+
+    cb.callback_unregister(cb2.id)
+    assert 'f2' not in cb.callback_valid_names()
+
+    cb._callback_execute('f', 1, 2, a=3)
+    func.assert_called_with(1, 2, a=3)

--- a/calvin/tests/test_calvinlogger.py
+++ b/calvin/tests/test_calvinlogger.py
@@ -1,0 +1,74 @@
+import pytest
+import json
+
+from mock import patch, Mock
+
+from calvin.utilities import calvinlogger
+
+
+@patch('calvin.utilities.calvinlogger.logging')
+def test_get_logger(logging_mock):
+    calvinlogger._log = None
+    log_mock = Mock()
+    logging_mock.getLogger = Mock(return_value=log_mock)
+
+    log = calvinlogger.get_logger()
+    assert logging_mock.getLogger.called
+    log_mock.setLevel.assert_called_with(logging_mock.INFO)
+    assert log == log_mock
+
+    log = calvinlogger.get_logger(name="abc")
+    assert log == log_mock.getChild("abc")
+
+
+@patch('calvin.utilities.calvinlogger._create_logger')
+def test_get_actor_logger(create_logger):
+    log_mock = Mock()
+    create_logger.return_value = log_mock
+    log = calvinlogger.get_actor_logger("abc")
+
+    assert create_logger.called
+    assert log == log_mock.getChild("abc")
+
+
+@patch('calvin.utilities.calvinlogger._create_logger')
+def test_set_file(create_logger):
+    calvinlogger.set_file("filename")
+    create_logger.assert_called_with("filename")
+
+
+@pytest.mark.parametrize("node_id,func,param,peer_node_id,tb,mute,args,kwargs", [
+    (1, "func", "param", 2, False, False, (1, 2, 3), {"kwargs": 1}),
+    (1, "func", "param", 2, True, True, (1, 2, 3), {"kwargs": 1}),
+    (1, "func", "param", 2, True, False, (1, 2, 3), {"kwargs": 1}),
+    (1, "func", "param", 2, True, False, None, None)
+])
+@patch.object(calvinlogger.traceback, "extract_stack", return_value="stack")
+def test_analyze(extract_stack, node_id, func, param, peer_node_id, tb, mute, args, kwargs):
+    calvinlogger._log = None
+    log = calvinlogger.get_logger()
+    log.isEnabledFor = Mock(return_value=True)
+    log._log = Mock()
+    log.analyze(node_id=node_id, func=func, param=param, peer_node_id=peer_node_id, tb=tb, mute=mute,
+                args=args, kwargs=kwargs)
+
+    if mute:
+        assert not log._log.called
+    else:
+        expected_stack = None
+        if tb:
+            expected_stack = "stack"
+
+        msg = "[[ANALYZE]]" + json.dumps({
+            "peer_node_id": peer_node_id,
+            "node_id": node_id,
+            "func": func,
+            "param": param,
+            "stack": expected_stack
+        })
+        log._log.assert_called_with(5, msg, (), args=args, kwargs=kwargs)
+
+        if tb:
+            assert extract_stack.called
+        else:
+            assert not extract_stack.called

--- a/calvin/tests/test_calvinresponse.py
+++ b/calvin/tests/test_calvinresponse.py
@@ -1,0 +1,36 @@
+
+from calvin.utilities.calvinresponse import RESPONSE_CODES, CalvinResponse
+
+
+def test_boolean_value():
+    success_list = range(200, 207)
+    for code in RESPONSE_CODES:
+        response = CalvinResponse(code)
+        if code in success_list:
+            assert response
+        else:
+            assert not response
+
+
+def test_comparisons():
+    first = CalvinResponse(100)
+    second = CalvinResponse(200)
+    third = CalvinResponse(200)
+
+    assert first < second
+    assert second > first
+    assert second == third
+    assert first != second
+    assert second <= third
+    assert third <= second
+
+
+def test_set_status():
+    response = CalvinResponse(100)
+    assert response.status == 100
+    response.set_status(400)
+    assert response.status == 400
+    response.set_status(True)
+    assert response.status == 200
+    response.set_status(False)
+    assert response.status == 500

--- a/calvin/tests/test_endpoint.py
+++ b/calvin/tests/test_endpoint.py
@@ -1,0 +1,211 @@
+import pytest
+import unittest
+from mock import Mock
+
+from calvin.actor.actorport import InPort, OutPort
+from calvin.runtime.north.calvin_token import Token
+from calvin.runtime.south.endpoint import LocalInEndpoint, LocalOutEndpoint, TunnelInEndpoint, TunnelOutEndpoint
+
+
+class TestLocalEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.port = InPort("port", Mock())
+        self.peer_port = OutPort("peer_port", Mock())
+        self.local_in = LocalInEndpoint(self.port, self.peer_port)
+        self.local_out = LocalOutEndpoint(self.peer_port, self.port)
+        self.port.attach_endpoint(self.local_in)
+        self.peer_port.attach_endpoint(self.local_out)
+
+    def test_is_connected(self):
+        assert self.local_in.is_connected
+        assert self.local_out.is_connected
+
+    def test_read_token_fixes_fifo_mismatch(self):
+        self.local_in.fifo_mismatch = True
+        token = self.local_in.read_token()
+        assert token is None
+        assert self.local_in.fifo_mismatch is False
+
+    def test_read_token_commits_if_token_is_not_none(self):
+        self.local_in.port.fifo.commit_reads = Mock()
+        self.local_out.port.fifo.commit_reads = Mock()
+        self.local_in.port.fifo.write(1)
+
+        assert self.local_in.data_in_local_fifo is True
+        assert self.local_in.read_token() == 1
+        assert self.local_in.data_in_local_fifo is True
+        self.local_in.port.fifo.commit_reads.assert_called_with(self.port.id, True)
+
+        self.local_out.port.fifo.write(2)
+
+        assert self.local_in.data_in_local_fifo is True
+        assert self.local_in.read_token() == 2
+        assert self.local_in.data_in_local_fifo is False
+        self.local_out.port.fifo.commit_reads.assert_called_with(self.port.id, True)
+
+    def test_peek_token(self):
+        self.local_in.port.fifo.commit_reads = Mock()
+        self.local_out.port.fifo.commit_reads = Mock()
+        self.local_in.port.fifo.write(1)
+
+        assert self.local_in.peek_token() == 1
+        assert not self.local_in.port.fifo.commit_reads.called
+        assert self.local_in.peek_token() is None
+        self.local_in.peek_rewind()
+        self.local_in.commit_peek_as_read()
+        self.local_in.port.fifo.commit_reads.assert_called_with(self.port.id)
+        self.local_out.port.fifo.commit_reads.assert_called_with(self.port.id)
+
+        self.local_in.port.fifo.commit_reads.reset_mock()
+        self.local_out.port.fifo.commit_reads.reset_mock()
+
+        self.local_out.port.fifo.write(2)
+        assert self.local_in.peek_token() == 2
+        assert not self.local_out.port.fifo.commit_reads.called
+        self.local_in.commit_peek_as_read()
+        assert not self.local_in.port.fifo.commit_reads.called
+        self.local_out.port.fifo.commit_reads.assert_called_with(self.port.id)
+
+    def test_available_tokens(self):
+        self.local_in.port.fifo.write(1)
+        self.local_in.port.fifo.write(1)
+        assert self.local_in.available_tokens() == 2
+        self.local_out.port.fifo.write(1)
+        assert self.local_in.available_tokens() == 3
+
+    def test_get_peer(self):
+        assert self.local_in.get_peer() == ('local', self.peer_port.id)
+        assert self.local_out.get_peer() == ('local', self.port.id)
+
+
+class TestTunnelEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.port = InPort("port", Mock())
+        self.peer_port = OutPort("peer_port", Mock())
+        self.tunnel = Mock()
+        self.trigger_loop = Mock()
+        self.node_id = 123
+        self.peer_node_id = 456
+        self.tunnel_in = TunnelInEndpoint(self.port, self.tunnel, self.peer_node_id, self.peer_port.id, self.trigger_loop)
+        self.tunnel_out = TunnelOutEndpoint(self.peer_port, self.tunnel, self.node_id, self.port.id, self.trigger_loop)
+        self.port.attach_endpoint(self.tunnel_in)
+        self.peer_port.attach_endpoint(self.tunnel_out)
+
+    def test_recv_token(self):
+        expected_reply = {
+            'cmd': 'TOKEN_REPLY',
+            'port_id': self.port.id,
+            'peer_port_id': self.peer_port.id,
+            'sequencenbr': 0,
+            'value': 'ACK'
+        }
+        payload = {
+            'port_id': self.port.id,
+            'peer_port_id': self.peer_port.id,
+            'sequencenbr': 0,
+            'token': {'type': 'Token', 'data': 5}
+        }
+        self.tunnel_in.recv_token(payload)
+        assert self.trigger_loop.called
+        assert self.port.fifo.fifo[0].value == 5
+        self.tunnel.send.assert_called_with(expected_reply)
+
+        self.trigger_loop.reset_mock()
+        self.tunnel.send.reset_mock()
+
+        payload['sequencenbr'] = 100
+        self.tunnel_in.recv_token(payload)
+        assert not self.trigger_loop.called
+        expected_reply['sequencenbr'] = 100
+        expected_reply['value'] = 'NACK'
+        self.tunnel.send.assert_called_with(expected_reply)
+
+        self.trigger_loop.reset_mock()
+        self.tunnel.send.reset_mock()
+
+        payload['sequencenbr'] = 0
+        self.tunnel_in.recv_token(payload)
+        assert not self.trigger_loop.called
+        expected_reply['sequencenbr'] = 0
+        expected_reply['value'] = 'ACK'
+        self.tunnel.send.assert_called_with(expected_reply)
+
+    def test_read_token(self):
+        self.tunnel_in.port.fifo.write(4)
+        self.tunnel_in.port.fifo.commit_reads = Mock()
+        assert self.tunnel_in.read_token() == 4
+        self.tunnel_in.port.fifo.commit_reads.assert_called_with(self.port.id, True)
+
+    def test_peek_token(self):
+        self.tunnel_in.port.fifo.write(4)
+        assert self.tunnel_in.peek_token() == 4
+        assert self.tunnel_in.read_token() is None
+        self.tunnel_in.peek_rewind()
+        assert self.tunnel_in.read_token() == 4
+
+    def test_available_tokens(self):
+        self.tunnel_in.port.fifo.write(4)
+        self.tunnel_in.port.fifo.write(5)
+        assert self.tunnel_in.available_tokens() == 2
+
+    def test_get_peer(self):
+        assert self.tunnel_in.get_peer() == (self.peer_node_id, self.peer_port.id)
+        assert self.tunnel_out.get_peer() == (self.node_id, self.port.id)
+
+    def test_reply(self):
+        self.tunnel_out.port.fifo.commit_one_read = Mock()
+
+        self.tunnel_out.port.write_token(Token(1))
+        self.tunnel_out._send_one_token()
+
+        self.tunnel_out.reply(0, 'ACK')
+        self.tunnel_out.port.fifo.commit_one_read.assert_called_with(self.port.id, True)
+        assert self.trigger_loop.called
+
+        self.tunnel_out.port.fifo.commit_one_read.reset_mock()
+        self.tunnel_out.reply(1, 'NACK')
+        assert not self.tunnel_out.port.fifo.commit_one_read.called
+
+    def test_nack_reply(self):
+        self.tunnel_out.port.write_token(Token(1))
+        self.tunnel_out._send_one_token()
+
+        self.tunnel_out.port.fifo.commit_reads(self.port.id, True)
+        assert self.tunnel_out.port.fifo.tentative_read_pos[self.port.id] == 1
+        assert self.tunnel_out.port.fifo.read_pos[self.port.id] == 1
+
+        self.tunnel_out.port.write_token(Token(2))
+        self.tunnel_out.port.write_token(Token(3))
+        self.tunnel_out._send_one_token()
+        self.tunnel_out._send_one_token()
+
+        assert self.tunnel_out.port.fifo.read_pos[self.port.id] == 1
+        assert self.tunnel_out.port.fifo.tentative_read_pos[self.port.id] == 3
+
+        self.tunnel_out.reply(1, 'NACK')
+        assert self.tunnel_out.port.fifo.tentative_read_pos[self.port.id] == 1
+        assert self.tunnel_out.port.fifo.read_pos[self.port.id] == 1
+
+    def test_bulk_communicate(self):
+        self.tunnel_out.port.write_token(Token(1))
+        self.tunnel_out.port.write_token(Token(2))
+        self.tunnel_out.bulk = True
+        self.tunnel_out.communicate()
+        assert self.tunnel.send.call_count == 2
+
+    def test_communicate(self):
+        self.tunnel_out.port.write_token(Token(1))
+        self.tunnel_out.port.write_token(Token(2))
+
+        self.tunnel_out.bulk = False
+
+        assert self.tunnel_out.communicate() is True
+        assert self.tunnel.send.call_count == 1
+
+        assert self.tunnel_out.communicate() is False
+
+        self.tunnel_out.reply(1, 'ACK')
+        assert self.tunnel_out.communicate() is True
+        assert self.tunnel.send.call_count == 2

--- a/calvin/utilities/calvinresponse.py
+++ b/calvin/utilities/calvinresponse.py
@@ -17,52 +17,52 @@
 import numbers
 
 RESPONSE_CODES = {  # Information
-                  100: 'Continue',
-                  101: 'Switching Protocols',
-                  # Success
-                  200: 'OK',  # Preferred
-                  201: 'Created',
-                  202: 'Accepted', #  Preferred
-                  203: 'Non-Authoritative Information',
-                  204: 'No Content',
-                  205: 'Reset Content',
-                  206: 'Partial Content',
-                  # Redirect
-                  300: 'Multiple Choices',
-                  301: 'Moved Permanently',
-                  302: 'Found',
-                  303: 'See Other',
-                  304: 'Not Modified',
-                  305: 'Use Proxy',
-                  306: '(Unused)',
-                  307: 'Temporary Redirect',
-                  # Client errors
-                  400: 'Bad Request',  # Preferred
-                  401: 'Unauthorized',
-                  402: 'Payment Required',
-                  403: 'Forbidden',
-                  404: 'Not Found',  # Preferred
-                  405: 'Method Not Allowed',
-                  406: 'Not Acceptable',
-                  407: 'Proxy Authentication Required',
-                  408: 'Request Timeout',
-                  409: 'Conflict',
-                  410: 'Gone',  # Preferred
-                  411: 'Length Required',
-                  412: 'Precondition Failed',
-                  413: 'Request Entity Too Large',
-                  414: 'Request-URI Too Long',
-                  415: 'Unsupported Media Type',
-                  416: 'Requested Range Not Satisfiable',
-                  417: 'Expectation Failed',
-                  # Server error
-                  500: 'Internal Server Error',  # Preferred
-                  501: 'Not Implemented',  # Preferred
-                  502: 'Bad Gateway',  # Preferred
-                  503: 'Service Unavailable',  # Preferred
-                  504: 'Gateway Timeout',  # Preferred
-                  505: 'HTTP Version Not Supported'
-                  }
+    100: 'Continue',
+    101: 'Switching Protocols',
+    # Success
+    200: 'OK',  # Preferred
+    201: 'Created',
+    202: 'Accepted',  # Preferred
+    203: 'Non-Authoritative Information',
+    204: 'No Content',
+    205: 'Reset Content',
+    206: 'Partial Content',
+    # Redirect
+    300: 'Multiple Choices',
+    301: 'Moved Permanently',
+    302: 'Found',
+    303: 'See Other',
+    304: 'Not Modified',
+    305: 'Use Proxy',
+    306: '(Unused)',
+    307: 'Temporary Redirect',
+    # Client errors
+    400: 'Bad Request',  # Preferred
+    401: 'Unauthorized',
+    402: 'Payment Required',
+    403: 'Forbidden',
+    404: 'Not Found',  # Preferred
+    405: 'Method Not Allowed',
+    406: 'Not Acceptable',
+    407: 'Proxy Authentication Required',
+    408: 'Request Timeout',
+    409: 'Conflict',
+    410: 'Gone',  # Preferred
+    411: 'Length Required',
+    412: 'Precondition Failed',
+    413: 'Request Entity Too Large',
+    414: 'Request-URI Too Long',
+    415: 'Unsupported Media Type',
+    416: 'Requested Range Not Satisfiable',
+    417: 'Expectation Failed',
+    # Server error
+    500: 'Internal Server Error',  # Preferred
+    501: 'Not Implemented',  # Preferred
+    502: 'Bad Gateway',  # Preferred
+    503: 'Service Unavailable',  # Preferred
+    504: 'Gateway Timeout',  # Preferred
+    505: 'HTTP Version Not Supported'
+}
 
 OK = 200
 CREATED = 201
@@ -76,6 +76,7 @@ BAD_GATEWAY = 502
 SERVICE_UNAVAILABLE = 503
 GATEWAY_TIMEOUT = 504
 
+
 class CalvinResponse(object):
     """A generic class for handling all responses between entities"""
     def __init__(self, status=OK, data=None, encoded=None):
@@ -87,7 +88,7 @@ class CalvinResponse(object):
         else:
             self.set_status(status)
             self.data = data
-            self.success_list = range(200,207)
+            self.success_list = range(200, 207)
 
     def __nonzero__(self):
         return self._status()
@@ -101,7 +102,7 @@ class CalvinResponse(object):
     def __eq__(self, other):
         """ When need to check if response is equal to specific code
             other can be another CalvinResponse object,
-            a status code 
+            a status code
         """
         if isinstance(other, CalvinResponse):
             return self.status == other.status
@@ -159,7 +160,8 @@ class CalvinResponse(object):
         return {'status': self.status, 'data': self.data, 'success_list': self.success_list}
 
     def __str__(self):
-        return str(self.status) + ", " + RESPONSE_CODES[self.status] + ((", " + str(self.data)) if self.data else "") 
+        return str(self.status) + ", " + RESPONSE_CODES[self.status] + ((", " + str(self.data)) if self.data else "")
+
 
 if __name__ == '__main__':
     r = CalvinResponse(OK)
@@ -170,12 +172,12 @@ if __name__ == '__main__':
         print "CORRECT", r
     else:
         print "INCORRECT", r
-    
+
     if r3:
         print "INCORRECT", r3
     else:
         print "CORRECT", r3
-    
+
     if r == OK:
         print "EQ CORRECT1"
     else:


### PR DESCRIPTION
In order to improve development speed, it would be beneficial to have more unit tests. It seems like most tests now are more integration/system tests, and they take a long time to run. More fast unit tests would be beneficial during development.

Also fixed some pep8.