### PR TITLE
CPU and RAM deployment parameters.

### DIFF
--- a/calvin/runtime/north/calvin_node.py
+++ b/calvin/runtime/north/calvin_node.py
@@ -49,6 +49,8 @@ from calvin.utilities import calvinuuid
 from calvin.utilities import certificate
 from calvin.utilities.calvinlogger import get_logger, set_file
 from calvin.utilities import calvinconfig
+from calvin.runtime.north.resource_monitor.cpu import CpuMonitor
+from calvin.runtime.north.resource_monitor.memory import MemMonitor
 
 _log = get_logger(__name__)
 _conf = calvinconfig.get()
@@ -132,6 +134,9 @@ class Node(object):
         self.proto = CalvinProto(self, self.network)
         self.pm = PortManager(self, self.proto)
         self.app_manager = appmanager.AppManager(self)
+
+        self.cpu_monitor = CpuMonitor(self.id, self.storage)
+        self.mem_monitor = MemMonitor(self.id, self.storage)
 
         # The initialization that requires the main loop operating is deferred to start function
         async.DelayedCall(0, self.start)
@@ -256,6 +261,8 @@ class Node(object):
 
         _log.analyze(self.id, "+", {})
         self.storage.delete_node(self, cb=deleted_node)
+        self.cpu_monitor.stop()
+        self.mem_monitor.stop()
         for link in self.network.list_direct_links():
             self.network.link_get(link).close()
 

--- a/calvin/runtime/north/control_apis/registry_api.py
+++ b/calvin/runtime/north/control_apis/registry_api.py
@@ -246,3 +246,34 @@ def handle_get_port(self, handle, connection, match, data, hdr):
         func=self.storage_cb, handle=handle, connection=connection))
 
 
+@handler(r"POST /node/resource/cpuAvail\sHTTP/1")
+@authentication_decorator
+def handle_resource_cpu_avail(self, handle, connection, match, data, hdr):
+    """
+    POST /node/resource/cpuAvail
+    Updates CPU availability in the local node
+    Body:
+    {
+        "value": <CPU avail (0,25,50,75,100)>
+    }
+    Response status code: OK or INTERNAL_ERROR
+    Response: none
+    """
+    self.node.cpu_monitor.set_avail(data['value'],
+        CalvinCB(func=self.storage_cb, handle=handle, connection=connection))
+
+@handler(r"POST /node/resource/memAvail\sHTTP/1")
+@authentication_decorator
+def handle_resource_mem_avail(self, handle, connection, match, data, hdr):
+    """
+    POST /node/resource/memAvail
+    Updates RAM availability in the local node
+    Body:
+    {
+        "value": <RAM avail (0,25,50,75,100)>
+    }
+    Response status code: OK or INTERNAL_ERROR
+    Response: none
+    """
+    self.node.mem_monitor.set_avail(data['value'],
+        CalvinCB(func=self.storage_cb, handle=handle, connection=connection))

--- a/calvin/runtime/north/resource_monitor/cpu.py
+++ b/calvin/runtime/north/resource_monitor/cpu.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from calvin.runtime.south.plugins.async import async
+from calvin.runtime.north.resource_monitor.helper import ResourceMonitorHelper
+from calvin.utilities.calvinlogger import get_logger
+
+_log = get_logger(__name__)
+
+class CpuMonitor(object):
+    def __init__(self, node_id, storage):
+        self.storage = storage
+        self.node_id = node_id
+        self.acceptable_avail = [0, 25, 50, 75, 100]
+        self.helper = ResourceMonitorHelper(node_id, storage)
+
+    def set_avail(self, avail, cb=None):
+        """
+        Sets the CPU availability of a node.
+        Acceptable range: [0, 25, 50, 75, 100]
+        """
+        if avail not in self.acceptable_avail:
+            _log.error("Invalid CPU avail value: %s" % str(avail))
+            if cb:
+                async.DelayedCall(0, cb, avail, False)
+            return
+
+        self.helper.set("nodeCpuAvail-", "cpuAvail", avail, cb)
+
+    def stop(self):
+        """
+        Stops monitoring, cleaning storage
+        """
+        # get old value to cleanup indexes
+        self.helper.set("nodeCpuAvail-", "cpuAvail", value=None, cb=None)
+        self.storage.delete(prefix="nodeCpuAvail-", key=self.node_id, cb=None)

--- a/calvin/runtime/north/resource_monitor/helper.py
+++ b/calvin/runtime/north/resource_monitor/helper.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from calvin.runtime.south.plugins.async import async
+from calvin.utilities.calvin_callback import CalvinCB
+from calvin.utilities.attribute_resolver import AttributeResolver
+from calvin.utilities.calvinlogger import get_logger
+
+_log = get_logger(__name__)
+
+class ResourceMonitorHelper(object):
+    def __init__(self, node_id, storage):
+        self.storage = storage
+        self.node_id = node_id
+
+    def _set_aux(self, key, value, prefix_index, new_value=None):
+        """
+        Auxiliary method to set indexes .
+        Removes old indexes before adding the new ones. Triggered by a get in the database
+        """
+        # if new value is exactly the same, we don't need to change anything..
+        if value is new_value:
+            _log.debug("%s, value: %s. Nothing changed, just return.." % (prefix_index, value))
+            return
+
+        # erase indexes related to old value
+        if value is not None:
+            old_data = AttributeResolver({"indexed_public": {prefix_index: str(value)}})
+            _log.debug("Removing " + str(key) + " for " + prefix_index + ": " + str(value))
+            for index in old_data.get_indexed_public():
+                self.storage.remove_index(index=index, value=key, root_prefix_level=2)
+
+        # insert the new ones
+        if new_value is not None:
+            new_data = AttributeResolver({"indexed_public": {prefix_index: str(new_value)}})
+            _log.debug("After possible removal, adding new node " + str(self.node_id) + " for " + prefix_index + ": " + str(new_value))
+            for index in new_data.get_indexed_public():
+                self.storage.add_index(index=index, value=self.node_id, root_prefix_level=4, cb=None)
+
+    def set(self, prefix, prefix_index, value, cb=None):
+        """
+        Sets a certain resource of a node.
+        Gets the old value to erase from indexes.
+        Parameters:
+        prefix: String used in storage for attribute, e.g. nodeCpuAvail.
+        prefix_index: String used in indexed_public structure for this field, e.g. cpuAvail.
+        value: new value to set.
+        cb: callback to receive response. Signature: cb(value, True/False) 
+        """
+
+        # get old value to cleanup indexes
+        self.storage.get(prefix=prefix, key=self.node_id, cb=CalvinCB(self._set_aux,
+            prefix_index=prefix_index, new_value=value))
+
+        self.storage.set(prefix=prefix, key=self.node_id, value=value, cb=None)
+        if cb:
+            async.DelayedCall(0, cb, value, True)
+

--- a/calvin/runtime/north/resource_monitor/memory.py
+++ b/calvin/runtime/north/resource_monitor/memory.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from calvin.runtime.south.plugins.async import async
+from calvin.runtime.north.resource_monitor.helper import ResourceMonitorHelper
+from calvin.utilities.calvinlogger import get_logger
+
+_log = get_logger(__name__)
+
+class MemMonitor(object):
+    def __init__(self, node_id, storage):
+        self.storage = storage
+        self.node_id = node_id
+        self.acceptable_avail = [0, 25, 50, 75, 100]
+        self.helper = ResourceMonitorHelper(node_id, storage)
+
+    def set_avail(self, avail, cb=None):
+        """
+        Sets the RAM availability of a node.
+        Acceptable range: [0, 25, 50, 75, 100]
+        """
+        if avail not in self.acceptable_avail:
+            _log.error("Invalid RAM avail value: " + str(avail))
+            if cb:
+                async.DelayedCall(0, cb, avail, False)
+            return
+
+        self.helper.set("nodeMemAvail-", "memAvail", avail, cb)
+
+    def stop(self):
+        """
+        Stops monitoring, cleaning storage
+        """
+        # get old value to cleanup indexes
+        self.helper.set("nodeMemAvail-", "memAvail", value=None, cb=None)
+        self.storage.delete(prefix="nodeMemAvail-", key=self.node_id, cb=None)

--- a/calvin/runtime/north/storage.py
+++ b/calvin/runtime/north/storage.py
@@ -655,7 +655,7 @@ class Storage(object):
     def _delete_node_cb(self, counter, org_cb, *args, **kwargs):
         _log.analyze(self.node.id, "+", {'counter': counter[0]})
         counter[0] = counter[0] - 1
-        if counter[0] == 0:
+        if counter[0] == 0 and org_cb:
             org_cb(*args, **kwargs)
 
     def _delete_node_timeout_cb(self, counter, org_cb):

--- a/calvin/runtime/north/tests/test_resource_monitor.py
+++ b/calvin/runtime/north/tests/test_resource_monitor.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+
+from calvin.runtime.north import storage
+from calvin.runtime.north.resource_monitor.cpu import CpuMonitor
+from calvin.runtime.north.resource_monitor.memory import MemMonitor
+from calvin.runtime.south.plugins.async import threads
+from calvin.utilities.calvin_callback import CalvinCB
+from calvin.utilities.attribute_resolver import AttributeResolver
+from calvin.tests.helpers_twisted import create_callback, wait_for
+import calvin.tests
+import pytest
+import time
+
+# So it skipps if we dont have twisted plugin
+def _dummy_inline(*args):
+    pass
+
+if not hasattr(pytest, 'inlineCallbacks'):
+    pytest.inlineCallbacks = _dummy_inline
+
+@pytest.mark.essential
+@pytest.mark.skipif(pytest.inlineCallbacks == _dummy_inline,
+                    reason="No inline twisted plugin enabled, please use --twisted to py.test")
+
+
+class TestCpuMonitor(object):
+    CPUAVAIL_INDEX_BASE = ['node', 'resource', 'cpuAvail']
+    CPUTOTAL_INDEX_BASE = ['node', 'attribute', 'cpuTotal']
+
+    @pytest.inlineCallbacks
+    def setup(self):
+        self.node = calvin.tests.TestNode(["127.0.0.1:5000"])
+        self.node.attributes = AttributeResolver({"indexed_public": {"cpuTotal": "1" }})
+        self.storage = storage.Storage(self.node)
+        self.cpu = CpuMonitor(self.node.id, self.storage)
+        self.done = False
+        self.storage.add_node(self.node)
+        yield threads.defer_to_thread(time.sleep, .01)
+
+    @pytest.inlineCallbacks
+    def teardown(self):
+        yield threads.defer_to_thread(time.sleep, .001)
+
+    def test_done(self):
+        return self.done
+
+    def cb(self, key, value):
+        self.get_ans = value
+        self.done = True
+
+    @pytest.inlineCallbacks
+    def test_avail_invalid(self):
+        """
+        Verify invalid values for CPU avail
+        """
+        for i in [-1, 40, 101]:
+            self.done = False
+            self.cpu.set_avail(i, CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == False
+
+    @pytest.inlineCallbacks
+    def test_avail_valid(self):
+        """
+        Test valid values for CPU avail.
+        Verify if storage is as expected
+        """
+        values = [0, 25, 50, 75, 100]
+        for i in values:
+            # verify set return
+            self.done = False
+            self.cpu.set_avail(i, CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == True
+
+            # verify nodeCpuAvail in DB
+            self.done = False
+            self.storage.get(prefix="nodeCpuAvail-", key=self.node.id, cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == i
+
+            # verify index ok and present for level i
+            self.done = False
+            self.storage.get_index(index=self.CPUAVAIL_INDEX_BASE + map(str, values[:values.index(i)+1]), cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.node.id in self.get_ans
+
+    @pytest.inlineCallbacks
+    def test_avail_change(self):
+        """
+        Verify if indexes are ok after a change in CPU avail.
+        Old value must be erased from indexes
+        """
+        self.cpu.set_avail(50)
+        self.cpu.set_avail(25, CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans == True
+
+        # node id must not be present at level 50, only at 25
+        self.done = False
+        self.storage.get_index(index=self.CPUAVAIL_INDEX_BASE + ['0', '25', '50'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+    @pytest.inlineCallbacks
+    def test_stop_node(self):
+        """
+        Verify if indexes are cleared after node stop
+        Old value must be erased from indexes
+        """
+        self.cpu.set_avail(25, CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans == True
+
+        self.done = False
+        self.storage.get_index(index=self.CPUAVAIL_INDEX_BASE + ['0', '25'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.node.id in self.get_ans
+
+        self.cpu.stop()
+        self.storage.delete_node(self.node)
+
+        # nodeCpuAvail must not exist
+        self.done = False
+        self.storage.get(prefix="nodeCpuAvail-", key=self.node.id, cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is False
+
+        # node id must not be present at level 25
+        self.done = False
+        self.storage.get_index(index=self.CPUAVAIL_INDEX_BASE + ['0', '25'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+        # no node in total indexes
+        self.done = False
+        self.storage.get_index(index=self.CPUTOTAL_INDEX_BASE + ['1'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+    @pytest.inlineCallbacks
+    def test_total_valid(self):
+        """
+        Test valid values for CPU power.
+        Verify if storage is as expected
+        """
+        values = ["1", "1000", "100000", "1000000", "10000000"]
+        for i in values:
+            # verify set return
+            self.done = False
+            self.node.attributes = AttributeResolver({"indexed_public": {"cpuTotal": i }})
+            self.storage.add_node(self.node, cb=self.cb)
+            yield wait_for(self.test_done)
+            assert self.get_ans == True
+
+            # verify index ok and present for level i
+            self.done = False
+            self.storage.get_index(index=self.CPUTOTAL_INDEX_BASE + map(str, values[:values.index(i)+1]), cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.node.id in self.get_ans
+
+
+class TestMemMonitor(object):
+    MEMAVAIL_INDEX_BASE = ['node', 'resource', 'memAvail']
+    MEMTOTAL_INDEX_BASE = ['node', 'attribute', 'memTotal']
+
+    @pytest.inlineCallbacks
+    def setup(self):
+        self.node = calvin.tests.TestNode(["127.0.0.1:5000"])
+        self.node.attributes = AttributeResolver({"indexed_public": {"memTotal": "10G" }})
+        self.storage = storage.Storage(self.node)
+        self.mem = MemMonitor(self.node.id, self.storage)
+        self.done = False
+        self.storage.add_node(self.node)
+        yield threads.defer_to_thread(time.sleep, .01)
+
+    @pytest.inlineCallbacks
+    def teardown(self):
+        yield threads.defer_to_thread(time.sleep, .001)
+
+    def test_done(self):
+        return self.done
+
+    def cb(self, key, value):
+        self.get_ans = value
+        self.done = True
+
+    @pytest.inlineCallbacks
+    def test_avail_invalid(self):
+        """
+        Verify invalid values for RAM avail
+        """
+        for i in [-1, 40, 101]:
+            self.done = False
+            self.mem.set_avail(i, CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == False
+
+    @pytest.inlineCallbacks
+    def test_avail_valid(self):
+        """
+        Test valid values for RAM avail.
+        Verify if storage is as expected
+        """
+        values = [0, 25, 50, 75, 100]
+        for i in values:
+            # verify set return
+            self.done = False
+            self.mem.set_avail(i, CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == True
+
+            # verify nodeMemAvail in DB
+            self.done = False
+            self.storage.get(prefix="nodeMemAvail-", key=self.node.id, cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.get_ans == i
+
+            # verify index ok and present for level i
+            self.done = False
+            self.storage.get_index(index=self.MEMAVAIL_INDEX_BASE + map(str, values[:values.index(i)+1]), cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.node.id in self.get_ans
+
+    @pytest.inlineCallbacks
+    def test_avail_change(self):
+        """
+        Verify if indexes are ok after a change in RAM avail.
+        Old value must be erased from indexes
+        """
+        self.mem.set_avail(50)
+        self.mem.set_avail(25, CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans == True
+
+        # node id must not be present at level 50, only at 25
+        self.done = False
+        self.storage.get_index(index=self.MEMAVAIL_INDEX_BASE + ['0', '25', '50'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+    @pytest.inlineCallbacks
+    def test_stop_node(self):
+        """
+        Verify if indexes are cleared after node stop
+        Old value must be erased from indexes
+        """
+        self.mem.set_avail(25, CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans == True
+
+        self.done = False
+        self.storage.get_index(index=self.MEMAVAIL_INDEX_BASE + ['0', '25'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.node.id in self.get_ans
+
+        self.mem.stop()
+        self.storage.delete_node(self.node)
+
+        # nodeMemAvail must not exist
+        self.done = False
+        self.storage.get(prefix="nodeMemAvail-", key=self.node.id, cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is False
+
+        # node id must not be present at level 25
+        self.done = False
+        self.storage.get_index(index=self.MEMAVAIL_INDEX_BASE + ['0', '25'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+        # no node in total indexes
+        self.done = False
+        self.storage.get_index(index=self.MEMTOTAL_INDEX_BASE + ['1K'], cb=CalvinCB(self.cb))
+        yield wait_for(self.test_done)
+        assert self.get_ans is None
+
+    @pytest.inlineCallbacks
+    def test_total_valid(self):
+        """
+        Test valid values for total RAM.
+        Verify if storage is as expected
+        """
+        values = ["1K", "100K", "1M", "100M", "1G", "10G"]
+        for i in values:
+            # verify set return
+            self.done = False
+            self.node.attributes = AttributeResolver({"indexed_public": {"memTotal": i }})
+            self.storage.add_node(self.node, cb=self.cb)
+            yield wait_for(self.test_done)
+            assert self.get_ans == True
+
+            # verify index ok and present for level i
+            self.done = False
+            self.storage.get_index(index=self.MEMTOTAL_INDEX_BASE + map(str, values[:values.index(i)+1]), cb=CalvinCB(self.cb))
+            yield wait_for(self.test_done)
+            assert self.node.id in self.get_ans

--- a/calvin/tests/test_calvincontrol.py
+++ b/calvin/tests/test_calvincontrol.py
@@ -78,7 +78,9 @@ def test_get_calvincontrol_returns_xxx():
     ("GET /index/abc123 HTTP/1", "abc123", "handle_get_index"),
     ("GET /storage/abc123 HTTP/1", "abc123", "handle_get_storage"),
     ("POST /storage/abc123 HTTP/1", "abc123", "handle_post_storage"),
-    ("OPTIONS /abc123 HTTP/1", None, "handle_options")
+    ("OPTIONS /abc123 HTTP/1", None, "handle_options"),
+    ("POST /node/resource/cpuAvail HTTP/1", 25, "handle_monitor_cpu_avail"),
+    ("POST /node/resource/memAvail HTTP/1", 25, "handle_monitor_mem_avail")
 ])
 
 def test_routes_correctly(url, match, handler):

--- a/calvin/utilities/tests/test_attribute_resolver.py
+++ b/calvin/utilities/tests/test_attribute_resolver.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import pytest
+
+from calvin.utilities.attribute_resolver import AttributeResolver
+
+class AttributeResolverTester(unittest.TestCase):
+
+    def test_cpu_resources(self):
+        """
+        Tests valid cpu resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"cpuAvail": "100"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'cpuAvail')
+        self.assertEqual(att_list[0][3], '0')
+        self.assertEqual(att_list[0][4], '25')
+        self.assertEqual(att_list[0][5], '50')
+        self.assertEqual(att_list[0][6], '75')
+        self.assertEqual(att_list[0][7], '100')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/resource/cpuAvail/0/25/50/75/100')
+
+    def test_cpu_invalid_value(self):
+        """
+        Tests invalid cpu resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"cpuAvail": "1"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'cpuAvail')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/resource/cpuAvail')
+
+    def test_cpu_total(self):
+        """
+        Tests valid CPU power in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"cpuTotal": "10000000"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'cpuTotal')
+        self.assertEqual(att_list[0][3], '1')
+        self.assertEqual(att_list[0][4], '1000')
+        self.assertEqual(att_list[0][5], '100000')
+        self.assertEqual(att_list[0][6], '1000000')
+        self.assertEqual(att_list[0][7], '10000000')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/attribute/cpuTotal/1/1000/100000/1000000/10000000')
+
+    def test_cpu_total_invalid_value(self):
+        """
+        Tests invalid CPU power in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"cpuTotal": "2"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'cpuTotal')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/attribute/cpuTotal')
+
+    def test_mem_avail(self):
+        """
+        Tests valid RAM resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"memAvail": "100"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'memAvail')
+        self.assertEqual(att_list[0][3], '0')
+        self.assertEqual(att_list[0][4], '25')
+        self.assertEqual(att_list[0][5], '50')
+        self.assertEqual(att_list[0][6], '75')
+        self.assertEqual(att_list[0][7], '100')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/resource/memAvail/0/25/50/75/100')
+
+    def test_cpu_affinity(self):
+        """
+        Tests cpu affinity parameter in indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"cpuAffinity": "dedicated"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'cpuAffinity')
+        self.assertEqual(att_list[0][3], 'dedicated')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/attribute/cpuAffinity/dedicated')
+
+    def test_mem_avail_invalid_value(self):
+        """
+        Tests invalid RAM resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"memAvail": "1"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'memAvail')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/resource/memAvail')
+
+    def test_mem_total(self):
+        """
+        Tests valid RAM resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"memTotal": "10G"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'memTotal')
+        self.assertEqual(att_list[0][3], '1K')
+        self.assertEqual(att_list[0][4], '100K')
+        self.assertEqual(att_list[0][5], '1M')
+        self.assertEqual(att_list[0][6], '100M')
+        self.assertEqual(att_list[0][7], '1G')
+        self.assertEqual(att_list[0][8], '10G')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/attribute/memTotal/1K/100K/1M/100M/1G/10G')
+
+    def test_mem_total_invalid_value(self):
+        """
+        Tests invalid RAM resources in the indexed_public field
+        """
+        att = AttributeResolver({"indexed_public": {"memTotal": "10K"}})
+        att_list = att.get_indexed_public(as_list=True)
+        self.assertEqual(att_list[0][2], 'memTotal')
+
+        self.assertEqual(att.get_indexed_public()[0], '/node/attribute/memTotal')


### PR DESCRIPTION
Hi @HaraldGustafsson

Here it is the first implementations to add CPU and RAM parameters as discussed in https://github.com/EricssonResearch/calvin-base/issues/83.

If you could give a look and say me your opinion so I can improve the missing points.
It depends on some external tool to update the CPU/RAM available in the runtime during execution and only consider them at the initial deployment. 

Regards,

Commit message:

Now it is possible to select the runtimes to run actors based on some
CPU and RAM parameters.

CPU parameters:
- Total CPU: power in MIPS of runtime.
The acceptable values are: 1 MIPS, 1000 MIPS, 100000 MIPS, 1 GIPS, 10
GIPS
- Available CPU: percentage of CPU available.
Acceptable values: 0%, 25%, 50%, 75%, 100%.
- Affinity: runtimes runs in a unique CPU core.
Acceptable values: "dedicated".

RAM parameters:
- Total RAM: Total memory available for runtime.
Acceptable values: 1Kb, 100Kb, 1Mb, 100Mb, 1Gb, 10Gb
- Available RAM: Percentage of memory available.
Acceptable values: 0%, 25%, 50%, 75%, 100%.

Other values must be rounded up/down if necessary.

2 groups of parameters:
- Fixed: they are attributes configured by command line when the runtime
  is started.
It contains: cpuTotal, cpuAffinity and memTotal.
- Variable: they can be changed during execution through the control
  API.
It includes: cpuAvail and memAvail.

How to use:
- Fixed: as another indexed_public parameter:
csruntime --name runtime-3 -n 192.168.0.2 --attr '{"indexed_public": {"memTotal": "100K", "cpuTotal": "100000"}}'

In the deployjson file, node has at least 1000 MIPS of CPU power:
{"requirements":{"snk":[{"op":"node_attr_match","kwargs":{"index":{"cpuTotal": "1000"}},"type":"+"}],

- Variable:
The deployjson file is similar to the fixed one. For at least 25% of CPU
available:
{"requirements":{"snk":[{"op":"node_attr_match","kwargs":{"index":{"cpuAvail": "25"}},"type":"+"}],

The update is done through control API, e.g. setting 50% of CPU
available:
curl -X POST -d '{"value": 50 }' http://192.168.0.1:5001/node/resource/cpuAvail
curl -X POST -d '{"value": 50 }' http://192.168.0.1:5001/node/resource/memAvail

Internal details:
- Storage structure for: cpuAvail and memAvail
/nodeCpuAvail-ID and /nodeMemAvail-ID: save percentage for ID runtime
/index-/cpuAvail/0/25/50/75/100 and /index-memAvail/0/25/50/75/100: save
the runtimes that have at least the percentage of resource available.
So, the ID of runtime-1 that has 50% RAM available can be recovered by
searching the lower indexes: /index-/memAvail/0/25 for example.

- Storage structure for: cpuTotal, memTotal and cpuAffinity.
Follows the structure of other public indexed attributes.