### PR TITLE
Make calvin run on fresh install

### DIFF
--- a/calvin/utilities/calvinconfig.py
+++ b/calvin/utilities/calvinconfig.py
@@ -189,7 +189,7 @@ class CalvinConfig(object):
         _section = self.config[section.lower()]
         _option = option.lower()
         old_value = _section.setdefault(_option, [])
-        if type(old_value) is not list:
+        if type(old_value) is not dict:
             raise Exception("Can't append, {}:{} is not a list".format(section, option))
         if type(value) is not list:
             raise Exception("Can't append, value is not a list")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ passlib==1.7.0
 PyJWT==1.4.0
 service-identity==17.0.0
 ndg-httpsclient==0.4.2
-pyasn1==0.1.9
+pyasn1==0.3.6
 pystache==0.5.4
 jsonschema==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='calvin',
           'PyJWT==1.4.0',
           'service-identity==17.0.0',
           'ndg-httpsclient==0.4.2',
-          'pyasn1==0.1.9',
+          'pyasn1==0.3.6',
           'pystache==0.5.4',
           'jsonschema==2.6.0'
       ],


### PR DESCRIPTION
Calvin throws an error on default configuration.
Check that configurable is a dict instead of a list

Step pyasn required version to satisfy everyone ..